### PR TITLE
Fixed the NeuroSettings Prefs taking non-digit characters.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "com.android.support:support-annotations:$rootProject.supportLibraryVersion"
     implementation "com.android.support:appcompat-v7:$rootProject.supportLibraryVersion"
-    implementation "com.android.support:preference-v7:$rootProject.supportLibraryVersion"
+    implementation "com.takisoft.fix:preference-v7:$rootProject.prefFixLibraryVersion"
     implementation "com.android.support:design:$rootProject.supportLibraryVersion"
     implementation "com.android.support:support-v4:$rootProject.supportLibraryVersion"
     implementation "com.android.support.constraint:constraint-layout:$rootProject.constraintLayoutVersion"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,7 +8,7 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/AppTheme">
+        android:theme="@style/EditTextPrefTheme">
         <activity
             android:name=".MainActivity"
             android:label="@string/app_name"

--- a/app/src/main/java/io/neurolab/MainActivity.java
+++ b/app/src/main/java/io/neurolab/MainActivity.java
@@ -65,7 +65,7 @@ public class MainActivity extends AppCompatActivity
 
                 @Override
                 public void onAnimationEnd(Animation animation) {
-                   moving = false;
+                    moving = false;
                 }
 
                 @Override

--- a/app/src/main/java/io/neurolab/NeuroSettingsFragment.java
+++ b/app/src/main/java/io/neurolab/NeuroSettingsFragment.java
@@ -3,28 +3,31 @@ package io.neurolab;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Bundle;
+import com.takisoft.fix.support.v7.preference.PreferenceFragmentCompat;
+import android.support.annotation.Nullable;
+import android.support.v7.preference.EditTextPreference;
 import android.support.v7.preference.Preference;
-import android.support.v7.preference.PreferenceFragmentCompat;
 import android.support.v7.preference.PreferenceScreen;
+import android.widget.EditText;
 
 public class NeuroSettingsFragment extends PreferenceFragmentCompat implements SharedPreferences.OnSharedPreferenceChangeListener, Preference.OnPreferenceChangeListener {
     Context context = getContext();
+    SharedPreferences sharedPreferences;
+    SharedPreferences.Editor editor;
 
     public NeuroSettingsFragment() {
 
     }
 
     @Override
-    public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
+    public void onCreatePreferencesFix(@Nullable Bundle savedInstanceState, String rootKey) {
         addPreferencesFromResource(R.xml.neuro_settings_fragment);
         Preference preference = findPreference(getResources().getString(R.string.samples_pref_key));
         preference.setOnPreferenceChangeListener(this);
+        sharedPreferences = getPreferenceScreen().getSharedPreferences();
 
-        SharedPreferences sharedPreferences = getPreferenceScreen().getSharedPreferences();
         PreferenceScreen preferenceScreen = getPreferenceScreen();
         int count = preferenceScreen.getPreferenceCount();
-
-
     }
 
     @Override
@@ -35,13 +38,13 @@ public class NeuroSettingsFragment extends PreferenceFragmentCompat implements S
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        getPreferenceScreen().getSharedPreferences().registerOnSharedPreferenceChangeListener(this);
+        sharedPreferences.registerOnSharedPreferenceChangeListener(this);
     }
 
     @Override
     public void onDestroyView() {
         super.onDestroyView();
-        getPreferenceScreen().getSharedPreferences().unregisterOnSharedPreferenceChangeListener(this);
+        sharedPreferences.unregisterOnSharedPreferenceChangeListener(this);
     }
 
     @Override

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -9,6 +9,13 @@
         <item name="preferenceTheme">@style/PreferenceThemeOverlay</item>
     </style>
 
+    <style name="EditTextPrefTheme" parent="@style/PreferenceFixTheme.Light.DarkActionBar">
+        <item name="colorPrimary">@color/colorPrimary</item>
+        <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
+        <item name="colorAccent">@color/colorAccent</item>
+        <item name="preferenceTheme">@style/PreferenceThemeOverlay</item>
+    </style>
+
     <style name="AppTheme.NoActionBar">
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>

--- a/app/src/main/res/xml/neuro_settings_fragment.xml
+++ b/app/src/main/res/xml/neuro_settings_fragment.xml
@@ -4,13 +4,22 @@
     <EditTextPreference
         android:defaultValue="3"
         android:key="@string/samples_pref_key"
+        android:inputType="numberDecimal"
+        android:digits="0123456789"
+        android:numeric="integer"
         android:title="@string/samples_pref_label" />
     <EditTextPreference
         android:defaultValue="4"
         android:key="@string/bins_pref_key"
+        android:inputType="numberDecimal"
+        android:digits="0123456789"
+        android:numeric="integer"
         android:title="@string/bins_pref_label" />
     <EditTextPreference
         android:defaultValue="2"
         android:key="@string/num_channels_pref_key"
+        android:inputType="numberDecimal"
+        android:digits="0123456789"
+        android:numeric="integer"
         android:title="@string/num_channels_pref_label" />
 </PreferenceScreen>

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ ext {
     // App Dependencies
     supportLibraryVersion = '28.0.0'
     constraintLayoutVersion = '1.1.3'
+    prefFixLibraryVersion = '28.0.0.0'
 
     // Test Dependencies
     testRunnerRulesVersion = '1.0.2'


### PR DESCRIPTION
Fixes #33 

**Changes**: I fixed the EditTextPrefs issue of taking input non-digit characters and crashing.

**Screenshot/s for the changes**: 
![screenshot_20190130-195151](https://user-images.githubusercontent.com/43133646/51990569-538b9e80-24cf-11e9-8bb0-94c373e8ccb8.png)


**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [ ] I have requested reviews from other members
