### PR TITLE
Fixed the getMedian() method in MathBasics class to work correctly for odd length inputs.

### DIFF
--- a/app/src/main/java/io/neurolab/MathBasics.java
+++ b/app/src/main/java/io/neurolab/MathBasics.java
@@ -14,7 +14,7 @@ public class MathBasics {
             double medianB = values[middle - 1];
             median = (medianA + medianB) / 2d;
         } else {
-            median = values[middle + 1];
+            median = values[middle];
         }
         return median;
     }


### PR DESCRIPTION
Fixes #35 

**Changes**:  Fixed the getMedian() method of MathBasics class to give correct output for odd length input array. Changed the RHS of the assignment statement (in the else clause of the method) to index the middle element of the values array instead of indexing the (middle + 1)th element of the array.

**Checklist**: 
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members
