### PR TITLE
Fix #56 : title and values aligned to each other in feedback settings fragment

### DIFF
--- a/app/src/main/res/layout/fragment_feedback_settings.xml
+++ b/app/src/main/res/layout/fragment_feedback_settings.xml
@@ -30,6 +30,7 @@
         <TextView
             android:id="@+id/feedback_smpls_label"
             style="@style/TextStyle"
+            android:gravity="center_vertical"
             android:layout_width="@dimen/dimen_for_weight"
             android:layout_height="match_parent"
             android:layout_weight=".8"
@@ -44,6 +45,7 @@
         <TextView
             android:id="@+id/feedback_smpls_value"
             style="@style/TextStyle"
+            android:gravity="center_vertical"
             android:layout_width="@dimen/dimen_for_weight"
             android:layout_height="match_parent"
             android:layout_weight=".3"
@@ -63,6 +65,7 @@
         <TextView
             android:id="@+id/feedback_bins_label"
             style="@style/TextStyle"
+            android:gravity="center_vertical"
             android:layout_width="@dimen/dimen_for_weight"
             android:layout_height="match_parent"
             android:layout_weight=".8"
@@ -77,6 +80,7 @@
         <TextView
             android:id="@+id/feedback_bins_value"
             style="@style/TextStyle"
+            android:gravity="center_vertical"
             android:layout_width="@dimen/dimen_for_weight"
             android:layout_height="match_parent"
             android:layout_weight=".3"
@@ -96,6 +100,7 @@
         <TextView
             android:id="@+id/feedback_numChannels_label"
             style="@style/TextStyle"
+            android:gravity="center_vertical"
             android:layout_width="@dimen/dimen_for_weight"
             android:layout_height="match_parent"
             android:layout_weight=".8"
@@ -110,6 +115,7 @@
         <TextView
             android:id="@+id/feedback_numChannels_value"
             style="@style/TextStyle"
+            android:gravity="center_vertical"
             android:layout_width="@dimen/dimen_for_weight"
             android:layout_height="match_parent"
             android:layout_weight=".3"


### PR DESCRIPTION
Fixes #56 

**Changes**:

added gravity : "center_vertical"

**Screenshot/s for the changes**: 
![screenshot_20190218-151314](https://user-images.githubusercontent.com/32041242/52942762-a13e4d00-3391-11e9-89a3-94415eee0ac8.png)


**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [ ] I have requested reviews from other members

**APK for testing**:
[feedbackSettings_value_align.zip](https://github.com/fossasia/neurolab-android/files/2875006/feedbackSettings_value_align.zip)
