### PR TITLE
Add navigate up button in fragment_feedback_settings #issue 66

### DIFF
--- a/app/src/main/java/io/neurolab/settings/FeedbackSettings.java
+++ b/app/src/main/java/io/neurolab/settings/FeedbackSettings.java
@@ -22,6 +22,11 @@ public class FeedbackSettings extends FragmentActivity implements SharedPreferen
     private TextView bins_txt_view;
     private TextView numChannels_txt_view;
 
+    @Override
+    public boolean onNavigateUp() {
+        onBackPressed();
+        return super.onNavigateUp();
+    }
     public FeedbackSettings() {
 
     }
@@ -36,6 +41,8 @@ public class FeedbackSettings extends FragmentActivity implements SharedPreferen
             activity.setActionBar(toolbar);
         }
         activity.getActionBar().setTitle(getResources().getString(R.string.app_name));
+        activity.getActionBar().setDisplayHomeAsUpEnabled(true);
+        activity.getActionBar().setDisplayShowHomeEnabled(true);
         sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this);
         smpls_per_sec = Integer.parseInt(sharedPreferences.getString(getResources().getString(R.string.samples_pref_key), "4"));
         bins = Integer.parseInt(sharedPreferences.getString(getResources().getString(R.string.bins_pref_key), "3"));

--- a/app/src/main/res/layout/fragment_feedback_settings.xml
+++ b/app/src/main/res/layout/fragment_feedback_settings.xml
@@ -10,6 +10,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="?attr/colorPrimary"
+    android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
     android:titleTextColor="@color/color_white_background"/>
 <LinearLayout
     android:layout_width="match_parent"


### PR DESCRIPTION
Fixes #66 

**Changes**:Added back button on the toolbar.
**Screenshot/s for the changes**: 
![screenshot_2019-03-02-11-11-47-74](https://user-images.githubusercontent.com/36455409/53677841-5ea73980-3cdc-11e9-91a4-678ba861dd03.png)

**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members
- [ ] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them

**APK for testing**: [app-debug.zip](https://github.com/fossasia/neurolab-android/files/2921794/app-debug.zip)
