### PR TITLE
Align values with text in fragment_feedback_settings file.

### DIFF
--- a/app/src/main/res/layout/fragment_feedback_settings.xml
+++ b/app/src/main/res/layout/fragment_feedback_settings.xml
@@ -58,6 +58,7 @@
             android:layout_width="@dimen/dimen_for_weight"
             android:layout_height="match_parent"
             android:layout_weight=".3"
+            android:gravity="center_vertical"
             android:padding="@dimen/bin_value_text_padding"/>
     </LinearLayout>
 
@@ -91,6 +92,7 @@
             android:layout_width="@dimen/dimen_for_weight"
             android:layout_height="match_parent"
             android:layout_weight=".3"
+            android:gravity="center_vertical"
             android:padding="@dimen/bin_value_text_padding"/>
     </LinearLayout>
 
@@ -124,6 +126,7 @@
             android:layout_width="@dimen/dimen_for_weight"
             android:layout_height="match_parent"
             android:layout_weight=".3"
+            android:gravity="center_vertical"
             android:padding="@dimen/bin_value_text_padding"/>
     </LinearLayout>
 


### PR DESCRIPTION
Fixes #56

**Changes**: Values are now aligned with the text.

**Screenshot/s for the changes**: Before 

![screenshot_2019-03-03-17-40-00-83](https://user-images.githubusercontent.com/36455409/53695051-e3797c80-3ddc-11e9-9dc8-d3b6f1494e94.png)

After i've applied new changes

![screenshot_2019-03-03-17-42-02-21](https://user-images.githubusercontent.com/36455409/53695060-fbe99700-3ddc-11e9-8457-17744afffabd.png)

**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [ ] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**: 
[app-debug.zip](https://github.com/fossasia/neurolab-android/files/2923102/app-debug.zip)


