### PR TITLE
Cleaned up the resources/memory by utilizing the onDestroy( ) callback.

### DIFF
--- a/app/src/main/java/io/neurolab/MainActivity.java
+++ b/app/src/main/java/io/neurolab/MainActivity.java
@@ -26,10 +26,17 @@ public class MainActivity extends AppCompatActivity
         implements NavigationView.OnNavigationItemSelectedListener {
 
     private int launcherSleepTime;
-    private ImageView rocketimage;
+
     private int lastPos = 0;
     private int newPos = -300;
     private boolean moving;
+    private ActionBarDrawerToggle toggle;
+
+    // View(s)/ViewGroup(s) references.
+    private ImageView rocketimage;
+    private DrawerLayout drawer;
+    private NavigationView navigationView;
+
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -42,13 +49,13 @@ public class MainActivity extends AppCompatActivity
 
         rocketimage = findViewById(R.id.rocketimage);
 
-        DrawerLayout drawer = findViewById(R.id.drawer_layout);
-        ActionBarDrawerToggle toggle = new ActionBarDrawerToggle(
+        drawer = findViewById(R.id.drawer_layout);
+        toggle = new ActionBarDrawerToggle(
                 this, drawer, toolbar, R.string.navigation_drawer_open, R.string.navigation_drawer_close);
         drawer.addDrawerListener(toggle);
         toggle.syncState();
 
-        NavigationView navigationView = findViewById(R.id.nav_view);
+        navigationView = findViewById(R.id.nav_view);
         navigationView.setNavigationItemSelectedListener(this);
     }
 
@@ -149,4 +156,14 @@ public class MainActivity extends AppCompatActivity
         drawer.closeDrawer(GravityCompat.START);
         return true;
     }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+
+        // Cleaning up the resources/memory.
+        drawer.removeDrawerListener(toggle);
+        navigationView.setNavigationItemSelectedListener(null);
+    }
+
 }


### PR DESCRIPTION
Fixes #86 

**Changes**: 

- Added the onDestroy( ) callback for cleaning up the resources/memory. Listeners are set to null/removed in the callback to prevent short-term memory leaks. 
- Apart from this, the PR also enforces an invariant of cleaning up the open-variables (listeners, database connections, network connections, file i/o etc) for the future contributions by the developers.

**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications are done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members