### PR TITLE
Made the NeuroSettings class Encapsulated

### DIFF
--- a/app/src/main/java/io/neurolab/NeuroSettings.java
+++ b/app/src/main/java/io/neurolab/NeuroSettings.java
@@ -3,13 +3,12 @@ package io.neurolab;
 
 public class NeuroSettings {
 
-
     //Default place holder values
-    public int samplesPerSecond = 3;
-    public int bins = 4;
-    public int numChannels = 2;
+    private int samplesPerSecond = 3;
+    private int bins = 4;
+    private int numChannels = 2;
 
-
+    // Constructors
     public NeuroSettings() {
     }
 
@@ -19,6 +18,7 @@ public class NeuroSettings {
         this.bins = bins;
     }
 
+    // Getters
     public int getSamplesPerSecond() {
         return samplesPerSecond;
     }
@@ -29,6 +29,19 @@ public class NeuroSettings {
 
     public int getNumChannels() {
         return numChannels;
+    }
+
+    // Setters
+    public void setSamplesPerSecond(int samplesPerSecond) {
+        this.samplesPerSecond = samplesPerSecond;
+    }
+
+    public void setBins(int bins) {
+        this.bins = bins;
+    }
+
+    public void setNumChannels(int numChannels) {
+        this.numChannels = numChannels;
     }
 
 }


### PR DESCRIPTION
Fixes #88 

**Changes**: 
Added encapsulation in NeuroSettings class by:
- Declaring the instance variables (samplesPerSecond, bins, numChannels) as private instead of public (earlier).
- Adding code robustness by implementing the setter methods which can then be used by other classes to interact/manipulate the instance variables safely.

**Checklist**: 
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members
