### PR TITLE
Fixed the Incorrect package name of NeuroUtils class

### DIFF
--- a/app/src/main/java/io/neurolab/NeuroUtils.java
+++ b/app/src/main/java/io/neurolab/NeuroUtils.java
@@ -1,4 +1,4 @@
-package org.neurovillage.main;
+package io.neurolab;
 
 import java.util.HashMap;
 


### PR DESCRIPTION
Fix #98

**Changes**: 
- Fixed the incorrect package name of NeuroUtils class by changing it to io.neurolab from org.neurovillage.main

**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members