### PR TITLE
Modified getResource() method of ResourceManager class to work correctly for Android

### DIFF
--- a/app/src/main/java/io/neurolab/tools/ResourceManager.java
+++ b/app/src/main/java/io/neurolab/tools/ResourceManager.java
@@ -1,12 +1,18 @@
 package io.neurolab.tools;
 
+import android.content.Context;
+import android.util.Log;
+
 import java.io.File;
 import java.net.URL;
 
 public class ResourceManager {
     public static ResourceManager resourceManager;
     private static ClassLoader classLoader;
-    public static boolean loadFromDisk = false;
+    public static boolean loadFromPhone = false;
+    private Context context;
+
+    private static String TAG = ResourceManager.class.getCanonicalName();
 
     public static ResourceManager getInstance() {
         if (resourceManager == null) {
@@ -16,13 +22,14 @@ public class ResourceManager {
         return resourceManager;
     }
 
-    public File getResource(String resourceName) {
-        System.out.println("loading resource '" + resourceName + "'");
+    public File getResource(Context context, String resourceName) {
+        this.context = context;
+        Log.d(TAG, "loading resource '" + resourceName + "'");
         if (resourceName.startsWith("ABSPATH:")) {
-            return new File(resourceName.substring(8));
+            return new File(this.context.getFilesDir(), resourceName.substring(8));
         }
-        if (loadFromDisk)
-            return new File("./resources/" + resourceName);
+        if (loadFromPhone)
+            return new File(this.context.getFilesDir(), "./resources/" + resourceName);
 
         URL resource = classLoader.getResource(resourceName);
         if (resource == null)


### PR DESCRIPTION
Fixes #17 partly.

**Changes**: 
- getResource() method of the ResourceManager class wasn't ported correctly from neurolab-desktop. Modified the method to work correctly with the android system.

**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members