### PR TITLE
Implemented Use of Shared Prefs in Launcher

### DIFF
--- a/app/src/main/java/io/neurolab/NeuroLauncherActivity.java
+++ b/app/src/main/java/io/neurolab/NeuroLauncherActivity.java
@@ -1,0 +1,14 @@
+package io.neurolab;
+
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.v7.app.AppCompatActivity;
+
+public class NeuroLauncherActivity extends AppCompatActivity {
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_launcher_prefs);
+    }
+}

--- a/app/src/main/java/io/neurolab/NeuroLauncherFragment.java
+++ b/app/src/main/java/io/neurolab/NeuroLauncherFragment.java
@@ -1,0 +1,78 @@
+package io.neurolab;
+
+import android.content.SharedPreferences;
+import android.os.Bundle;
+import android.support.v14.preference.PreferenceFragment;
+import android.support.v7.preference.Preference;
+
+public class NeuroLauncherFragment extends PreferenceFragment
+        implements SharedPreferences.OnSharedPreferenceChangeListener,
+        Preference.OnPreferenceChangeListener {
+    private SharedPreferences sharedPreferences;
+
+    private boolean simulation;
+    private boolean loadResources;
+    private boolean audioFeedback;
+    private boolean mode24bit;
+    private boolean modeAdvanced;
+
+    @Override
+    public void onCreatePreferences(Bundle bundle, String s) {
+        addPreferencesFromResource(R.xml.launcher_preference_screen);
+        Preference preference = findPreference(getResources().getString(R.string.simulation));
+        preference.setOnPreferenceChangeListener(this);
+        sharedPreferences = getPreferenceScreen().getSharedPreferences();
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        sharedPreferences.registerOnSharedPreferenceChangeListener(this);
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        sharedPreferences.unregisterOnSharedPreferenceChangeListener(this);
+    }
+
+    @Override
+    public boolean onPreferenceChange(Preference preference, Object o) {
+        return true;
+    }
+
+    @Override
+    public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
+       if(key.equals(getResources().getString(R.string.simulation))){
+           simulation = sharedPreferences.getBoolean(key, false);
+       }else if(key.equals(getResources().getString(R.string.load_from_phone))){
+           loadResources = sharedPreferences.getBoolean(key, false);
+       }else if(key.equals(getResources().getString(R.string.audio_feedback))){
+           audioFeedback = sharedPreferences.getBoolean(key, false);
+       }else if(key.equals(getResources().getString(R.string.mode_24bit))){
+           mode24bit = sharedPreferences.getBoolean(key, false);
+       }else {
+           modeAdvanced = sharedPreferences.getBoolean(key, false);
+       }
+    }
+
+    public boolean isSimulation() {
+        return simulation;
+    }
+
+    public boolean isLoadResources() {
+        return loadResources;
+    }
+
+    public boolean isAudioFeedback() {
+        return audioFeedback;
+    }
+
+    public boolean isMode24bit() {
+        return mode24bit;
+    }
+
+    public boolean isModeAdvanced() {
+        return modeAdvanced;
+    }
+}

--- a/app/src/main/res/layout/activity_launcher_prefs.xml
+++ b/app/src/main/res/layout/activity_launcher_prefs.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<fragment xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:name="io.neurolab.NeuroLauncherFragment"
+    tools:context=".NeuroLauncherActivity">
+
+</fragment>

--- a/app/src/main/res/layout/content_main.xml
+++ b/app/src/main/res/layout/content_main.xml
@@ -24,43 +24,16 @@
             android:text="@string/settings"
             android:textSize="@dimen/launcher_title_text_size"
             android:textStyle="bold" />
-
         <LinearLayout
             android:id="@+id/settings_linear_layout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_below="@id/cbs_text_view_title"
-            android:orientation="vertical">
+            android:orientation="vertical"
+            android:layout_alignParentStart="true"
+            android:layout_alignParentLeft="true"
+            android:paddingTop="@dimen/content_padding">
 
-            <CheckBox
-                android:id="@+id/cb_simulation"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/simulation" />
-
-            <CheckBox
-                android:id="@+id/cb_load_resources_from_phone"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/load_from_phone" />
-
-            <CheckBox
-                android:id="@+id/cb_audio_feedback"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/audio_feedback" />
-
-            <CheckBox
-                android:id="@+id/cb_24bit"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/mode_24bit" />
-
-            <CheckBox
-                android:id="@+id/cb_advanced_mode"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/mode_advanced" />
+            <include layout="@layout/activity_launcher_prefs" />
 
         </LinearLayout>
 
@@ -139,27 +112,4 @@
         </LinearLayout>
 
     </RelativeLayout>
-
-    <!--    <RelativeLayout
-            android:layout_width="match_parent"
-            android:layout_height="match_parent">
-
-            <ImageView
-                android:id="@+id/rocketimage"
-                android:layout_width="wrap_content"
-                android:layout_height="@dimen/rocket_image_height"
-                android:layout_alignParentStart="true"
-                android:layout_alignParentLeft="true"
-                android:layout_alignParentEnd="true"
-                android:layout_alignParentRight="true"
-                android:layout_alignParentBottom="true"
-                android:layout_marginStart="@dimen/rocket_image_margin_start"
-                android:layout_marginLeft="@dimen/rocket_image_margin_start"
-                android:layout_marginEnd="@dimen/rocket_image_margin_end"
-                android:layout_marginRight="@dimen/rocket_image_margin_end"
-                android:onClick="moveRocket"
-                android:src="@drawable/ic_rocket_image" />
-
-        </RelativeLayout>-->
-
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -26,4 +26,5 @@
     <dimen name="child_program_linear_layout_margin">8dp</dimen>
     <dimen name="launcher_btn_height">80dp</dimen>
     <dimen name="launcher_btn_width">0dp</dimen>
+    <dimen name="content_padding">15dp</dimen>
 </resources>

--- a/app/src/main/res/xml/launcher_preference_screen.xml
+++ b/app/src/main/res/xml/launcher_preference_screen.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <CheckBoxPreference
+        android:title="@string/simulation"
+        android:key="@string/simulation" />
+
+    <CheckBoxPreference
+        android:title="@string/load_from_phone"
+        android:key="@string/load_from_phone" />
+
+    <CheckBoxPreference
+        android:title="@string/audio_feedback"
+        android:key="@string/audio_feedback" />
+
+    <CheckBoxPreference
+        android:title="@string/mode_24bit"
+        android:key="@string/mode_24bit" />
+
+    <CheckBoxPreference
+        android:title="@string/mode_advanced"
+        android:key="@string/mode_advanced" />
+</PreferenceScreen>


### PR DESCRIPTION
Fixes #128 

**Changes**: Now whenever the user opens the app. His last checked preferences shall be stored.

**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [ ] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

