### PR TITLE
Improvement of the class FocusAudioFeedback 

### DIFF
--- a/app/src/main/java/io/neurolab/main/NFBServer.java
+++ b/app/src/main/java/io/neurolab/main/NFBServer.java
@@ -1,4 +1,4 @@
-package io.neurolab;
+package io.neurolab.main;
 
 import android.annotation.TargetApi;
 import android.os.Build;
@@ -9,6 +9,7 @@ import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.locks.ReentrantLock;
 
 import io.neurolab.model.Task;
+import io.neurolab.settings.NeuroSettings;
 
 @TargetApi(Build.VERSION_CODES.LOLLIPOP)
 public class NFBServer extends NeuroSettings implements DataReceiver {

--- a/app/src/main/java/io/neurolab/main/output/audio/FocusAudioFeedback.java
+++ b/app/src/main/java/io/neurolab/main/output/audio/FocusAudioFeedback.java
@@ -18,7 +18,7 @@ import io.neurolab.settings.FeedbackSettings;
 import io.neurolab.tools.ResourceManager;
 
 public class FocusAudioFeedback extends Feedback {
-
+    
     private Context context;
     private Synthesizer synth;
     private JSynThread jsynThread;
@@ -37,7 +37,6 @@ public class FocusAudioFeedback extends Feedback {
     @Override
     public void run() {
         this.synth = JSyn.createSynthesizer(AudioDeviceFactory.createAudioDeviceManager(true));
-        this.synth = jsynThread.getSynth();
 
         this.synth.add(lineOut = new LineOut());
         try {
@@ -80,6 +79,7 @@ public class FocusAudioFeedback extends Feedback {
         command.setCrossFadeIn(crossFadeSize);
 
         System.out.println("Queue: " + loopStartFrame + ", #" + loopSize + ", X=" + crossFadeSize);
+
         synth.queueCommand(command);
 
         running = true;
@@ -90,7 +90,6 @@ public class FocusAudioFeedback extends Feedback {
     public void updateCurrentFeedback(double currentFeedback) {
         super.updateCurrentFeedback(currentFeedback);
         samplePlayer.amplitude.set(Math.max(currentFeedback, 0));
-        samplePlayer.amplitude.set(Math.max(Math.min(1d, currentFeedback), 0d));
     }
 
 }


### PR DESCRIPTION
Fixes #168

**Changes**: 
* Removing the incorrect and redundant line regarding the setting the _samplePlayer.amplitude_ variable as well _this.synth_ variable in updateCurrentFeedback( ) and the run( ) methods respectively.

**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications are done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members
