### PR TITLE
App Crash fixed when settings clicked

### DIFF
--- a/app/src/main/res/layout/activity_neurosettings.xml
+++ b/app/src/main/res/layout/activity_neurosettings.xml
@@ -2,7 +2,7 @@
 <fragment xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:name="io.neurolab.main.NeuroSettingsFragment"
+    android:name="io.neurolab.fragments.NeuroSettingsFragment"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     tools:context=".main.NeuroSettingsActivity">


### PR DESCRIPTION
Fixes #205 

**Changes**: App does not crash now.

**Screenshot/s for the changes**: 
![neuro](https://user-images.githubusercontent.com/37077735/58043916-16b9e500-7b5c-11e9-8c88-91e0a46f7ce9.jpg)


**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**: 
[app-debug.zip](https://github.com/fossasia/neurolab-android/files/3199278/app-debug.zip)

