### PR TITLE
fix: removed space to left in settings

### DIFF
--- a/app/src/main/java/io/neurolab/fragments/NeuroSettingsFragment.java
+++ b/app/src/main/java/io/neurolab/fragments/NeuroSettingsFragment.java
@@ -1,40 +1,56 @@
 package io.neurolab.fragments;
 
-import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Bundle;
-import com.takisoft.fix.support.v7.preference.PreferenceFragmentCompat;
 import android.support.annotation.Nullable;
 import android.support.v7.preference.EditTextPreference;
-import android.support.v7.preference.Preference;
-import android.support.v7.preference.PreferenceScreen;
-import android.widget.EditText;
+
+import com.takisoft.fix.support.v7.preference.PreferenceFragmentCompat;
 
 import io.neurolab.R;
 
-public class NeuroSettingsFragment extends PreferenceFragmentCompat implements SharedPreferences.OnSharedPreferenceChangeListener, Preference.OnPreferenceChangeListener {
-    Context context = getContext();
-    SharedPreferences sharedPreferences;
-    SharedPreferences.Editor editor;
+public class NeuroSettingsFragment extends PreferenceFragmentCompat implements SharedPreferences.OnSharedPreferenceChangeListener {
 
-    public NeuroSettingsFragment() {
+    public static final String KEY_SAMPLES = "samples";
+    public static final String KEY_BINS = "bins";
+    public static final String KEY_CHANNELS = "numChannels";
 
-    }
+    private EditTextPreference samplesPref;
+    private EditTextPreference binsPref;
+    private EditTextPreference channelsPref;
+
+    private SharedPreferences sharedPreferences;
 
     @Override
     public void onCreatePreferencesFix(@Nullable Bundle savedInstanceState, String rootKey) {
-        addPreferencesFromResource(R.xml.neuro_settings_fragment);
-        Preference preference = findPreference(getResources().getString(R.string.samples_pref_key));
-        preference.setOnPreferenceChangeListener(this);
+        setPreferencesFromResource(R.xml.neuro_settings_fragment, rootKey);
+        // Assign preferences to use in this class
+        samplesPref = (EditTextPreference) getPreferenceScreen().findPreference(KEY_SAMPLES);
+        binsPref = (EditTextPreference) getPreferenceScreen().findPreference(KEY_BINS);
+        channelsPref = (EditTextPreference) getPreferenceScreen().findPreference(KEY_CHANNELS);
+        // Fetch related shared preferences
         sharedPreferences = getPreferenceScreen().getSharedPreferences();
-
-        PreferenceScreen preferenceScreen = getPreferenceScreen();
-        int count = preferenceScreen.getPreferenceCount();
     }
 
     @Override
     public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
-
+        switch (key) {
+            // TODO: Set limits to following preferences
+            case KEY_SAMPLES:
+                samplesPref.setSummary(samplesPref.getText() + " sample" +
+                        pluralize(Integer.valueOf(samplesPref.getText())));
+                break;
+            case KEY_BINS:
+                binsPref.setSummary(binsPref.getText() + " bin" +
+                        pluralize(Integer.valueOf(binsPref.getText())));
+                break;
+            case KEY_CHANNELS:
+                channelsPref.setSummary(channelsPref.getText() + " channel" +
+                        pluralize(Integer.valueOf(channelsPref.getText())));
+                break;
+            default:
+                break;
+        }
     }
 
     @Override
@@ -50,7 +66,17 @@ public class NeuroSettingsFragment extends PreferenceFragmentCompat implements S
     }
 
     @Override
-    public boolean onPreferenceChange(Preference preference, Object newValue) {
-        return true;
+    public void onResume() {
+        super.onResume();
+        samplesPref.setSummary(samplesPref.getText() + " sample" +
+                pluralize(Integer.valueOf(samplesPref.getText())));
+        binsPref.setSummary(binsPref.getText() + " bin" +
+                pluralize(Integer.valueOf(binsPref.getText())));
+        channelsPref.setSummary(channelsPref.getText() + " channel" +
+                pluralize(Integer.valueOf(channelsPref.getText())));
+    }
+
+    private String pluralize(int count) {
+        return count > 1 ? "s" : "";
     }
 }

--- a/app/src/main/res/xml/neuro_settings_fragment.xml
+++ b/app/src/main/res/xml/neuro_settings_fragment.xml
@@ -1,25 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
-<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <EditTextPreference
         android:defaultValue="3"
-        android:key="@string/samples_pref_key"
-        android:inputType="numberDecimal"
         android:digits="0123456789"
+        android:inputType="numberDecimal"
+        android:key="@string/samples_pref_key"
         android:numeric="integer"
-        android:title="@string/samples_pref_label" />
+        android:title="@string/samples_pref_label"
+        app:iconSpaceReserved="false" />
     <EditTextPreference
         android:defaultValue="4"
-        android:key="@string/bins_pref_key"
-        android:inputType="numberDecimal"
         android:digits="0123456789"
+        android:inputType="numberDecimal"
+        android:key="@string/bins_pref_key"
         android:numeric="integer"
-        android:title="@string/bins_pref_label" />
+        android:title="@string/bins_pref_label"
+        app:iconSpaceReserved="false" />
     <EditTextPreference
         android:defaultValue="2"
-        android:key="@string/num_channels_pref_key"
-        android:inputType="numberDecimal"
         android:digits="0123456789"
+        android:inputType="numberDecimal"
+        android:key="@string/num_channels_pref_key"
         android:numeric="integer"
-        android:title="@string/num_channels_pref_label" />
+        android:title="@string/num_channels_pref_label"
+        app:iconSpaceReserved="false" />
 </PreferenceScreen>


### PR DESCRIPTION
Fixes #55 and Fixes #73 

**Changes**: Removed left side spacing from settings

**Screenshot/s for the changes**: 
<table>
<tr><th>#55</th><th>#73</th></tr>
<tr><td><img src="https://user-images.githubusercontent.com/14261304/58459375-ddc7d480-8148-11e9-8719-bf3431005622.png" width="200" /></td><td><img src="https://user-images.githubusercontent.com/14261304/58462770-29ca4780-8150-11e9-95de-5ffe517663a1.png" width="200" /></td></tr>
</table>

**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [X] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [X] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [X] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [X] My code does not contain any extra lines or extra spaces
- [X] I have requested reviews from other members

**APK for testing**: 
[settingsfix.zip](https://github.com/fossasia/neurolab-android/files/3226316/settingsfix.zip)