### PR TITLE
Border added for app main window at the bottom

### DIFF
--- a/app/src/main/res/layout/content_main.xml
+++ b/app/src/main/res/layout/content_main.xml
@@ -69,6 +69,7 @@
         android:layout_marginTop="@dimen/layout_margin_large"
         android:layout_marginEnd="@dimen/layout_margin_large"
         android:layout_marginRight="@dimen/layout_margin_large"
+        android:layout_marginBottom="@dimen/layout_margin_large"
         app:cardElevation="@dimen/card_elevation"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"


### PR DESCRIPTION
Fixes #261

**Changes**: 
* Border added for the app window at the bottom to make it pleasing to look and to abide by Material Design Guidelines.

**Screenshot/s for the changes**: 
![img](https://user-images.githubusercontent.com/22399995/58582186-d00c6f00-826e-11e9-823f-29a75802b105.jpg)

**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications are done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members