### PR TITLE
Fixed the return button working while setting edit text preferences

### DIFF
--- a/app/src/main/java/io/neurolab/fragments/NeuroSettingsFragment.java
+++ b/app/src/main/java/io/neurolab/fragments/NeuroSettingsFragment.java
@@ -1,15 +1,21 @@
 package io.neurolab.fragments;
 
+import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
-import android.support.v7.preference.EditTextPreference;
+import android.view.KeyEvent;
+import android.view.inputmethod.EditorInfo;
+import android.view.inputmethod.InputMethodManager;
+import android.widget.TextView;
+
+import com.takisoft.fix.support.v7.preference.EditTextPreference;
 
 import com.takisoft.fix.support.v7.preference.PreferenceFragmentCompat;
 
 import io.neurolab.R;
 
-public class NeuroSettingsFragment extends PreferenceFragmentCompat implements SharedPreferences.OnSharedPreferenceChangeListener {
+public class NeuroSettingsFragment extends PreferenceFragmentCompat implements SharedPreferences.OnSharedPreferenceChangeListener, TextView.OnEditorActionListener {
 
     public static final String KEY_SAMPLES = "samples";
     public static final String KEY_BINS = "bins";
@@ -56,6 +62,9 @@ public class NeuroSettingsFragment extends PreferenceFragmentCompat implements S
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        samplesPref.getEditText().setOnEditorActionListener(this);
+        binsPref.getEditText().setOnEditorActionListener(this);
+        channelsPref.getEditText().setOnEditorActionListener(this);
         sharedPreferences.registerOnSharedPreferenceChangeListener(this);
     }
 
@@ -78,6 +87,16 @@ public class NeuroSettingsFragment extends PreferenceFragmentCompat implements S
 
     private String pluralize(int count) {
         return count > 1 ? "s" : "";
+    }
+
+    @Override
+    public boolean onEditorAction(TextView v, int actionId, KeyEvent event) {
+        if(actionId == EditorInfo.IME_ACTION_DONE){
+            InputMethodManager imm = (InputMethodManager) v.getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
+            imm.hideSoftInputFromWindow(v.getWindowToken(), 0);
+            return true;
+        }
+        return false;
     }
 
 }

--- a/app/src/main/res/xml/fragment_neuro_settings.xml
+++ b/app/src/main/res/xml/fragment_neuro_settings.xml
@@ -9,6 +9,7 @@
         android:key="@string/samples_pref_key"
         android:numeric="integer"
         android:title="@string/samples_pref_label"
+        android:imeOptions="actionDone"
         app:iconSpaceReserved="false" />
 
     <EditTextPreference
@@ -18,6 +19,7 @@
         android:key="@string/bins_pref_key"
         android:numeric="integer"
         android:title="@string/bins_pref_label"
+        android:imeOptions="actionDone"
         app:iconSpaceReserved="false" />
 
     <EditTextPreference
@@ -27,6 +29,7 @@
         android:key="@string/num_channels_pref_key"
         android:numeric="integer"
         android:title="@string/num_channels_pref_label"
+        android:imeOptions="actionDone"
         app:iconSpaceReserved="false" />
 
 </PreferenceScreen>


### PR DESCRIPTION
Fixes #76.

**Changes**: 
* Keyboard enter key is working as "ok" button (tick key) when changing values in settings preferences (the soft keyboard closes whenever you click the ‘DONE’ button)
    1. Return icon is being changed to a tick icon 
    2. Return button is closing the soft keyboard.

**Screenshot/s for the changes**:
<img src = "https://user-images.githubusercontent.com/22399995/59232692-1cf32c80-8c03-11e9-9a8f-e32fc74f9a85.gif" height = 500>

**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications are done at the end of resource files `strings.xml`,
 `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**: 
[app-debug.zip](https://github.com/fossasia/neurolab-android/files/3274122/app-debug.zip)