### PR TITLE
Downgraded AppIntro for supporting older versions

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -62,6 +62,6 @@ dependencies {
     implementation 'de.hdodenhof:circleimageview:3.0.0'
     implementation 'com.github.PhilJay:MPAndroidChart:v3.1.0'
     implementation 'com.github.felHR85:UsbSerial:6.0.6'
-    implementation 'com.github.AppIntro:AppIntro:v5.1.0'
+    implementation 'com.github.AppIntro:AppIntro:4.2.3'
     implementation 'org.jfree:jfreechart:1.0.14'
 }


### PR DESCRIPTION
Fixes the build failure.

**Changes**: 
* Downgraded AppIntro for supporting older versions and for resolving the build failure.

**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications are done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK**
[app-debug.zip](https://github.com/fossasia/neurolab-android/files/3306618/app-debug.zip)