### PR TITLE
Record Dialog with Stop functionality

### DIFF
--- a/app/src/main/res/layout/record_dialog_layout.xml
+++ b/app/src/main/res/layout/record_dialog_layout.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="horizontal">
+
+    <ProgressBar
+        android:id="@+id/progress_bar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="@dimen/padding_medium"
+        android:layout_gravity="center_vertical"
+        android:padding="@dimen/padding_medium"
+        android:indeterminate="true" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_vertical"
+        android:paddingEnd="@dimen/padding_small"
+        android:text="@string/recording_message"
+        android:textSize="@dimen/text_size_larger"/>
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -142,6 +142,8 @@ A difference to existing projects like OpenBCI is that it will not be necessary 
     <string name="author_elisha">Elisha Goldstein</string>
     <string name="default_timer">00:00</string>
     <string name="recording_message">Recording Data…</string>
+    <string name="no_device">No Device Connected</string>
+    <string name="no_rec_msg">Please connect the Neurolab device to start a recording</string>
     <string name="yes_focus_msg">Yes, Start</string>
     <string name="focus_test_msg">Test Data</string>
     <string name="focus_rec_ins">Please ensure neurolab device is connected to play this game or play test data.</string>


### PR DESCRIPTION
Fixes #383 

**Changes**: Record Dialog with Stop functionality. On Clicking Stop, the recording stops at that point and the recorded file is created accordingly. After recording control moves to Data Logger Activity.

**Screenshot/s for the changes**: 
<img src="https://user-images.githubusercontent.com/43133646/62133356-432c7300-b2fc-11e9-8744-5e230a0a5804.jpeg" width=200/> <img src="https://user-images.githubusercontent.com/43133646/62133409-56d7d980-b2fc-11e9-8c7f-273e7e7235e3.jpeg" width=200/> <img src="https://user-images.githubusercontent.com/43133646/62133438-6525f580-b2fc-11e9-8445-00c0775d16a0.jpeg" width=200/>

**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [ ] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**: 
https://drive.google.com/open?id=1UtOvn1PiFrYS9NvPZDRGyF0QtBWj_Iss