### PR TITLE
chore: generate app bundles

### DIFF
--- a/scripts/upload-apk.sh
+++ b/scripts/upload-apk.sh
@@ -14,6 +14,9 @@ if [ "$TRAVIS_PULL_REQUEST" != "false" -o "$TRAVIS_REPO_SLUG" != "fossasia/neuro
     exit 0
 fi
 
+# Generates app bundle
+./gradlew bundleRelease
+
 # Clone the repository
 git clone --quiet --branch=apk https://fossasia:$GITHUB_KEY@github.com/fossasia/neurolab-android apk > /dev/null
 


### PR DESCRIPTION
Fixes #401 

**Changes**: 
- Updated `upload-apk.sh` script to generate app bundles on the fly

**Screenshot/s for the changes**: 
> Not available

**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [X] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [X] My code does not contain any extra lines or extra spaces

**APK for testing**: 
> Not available
