### PR TITLE
Bug Fixed : Issue #446 App closes on clicking back button from Setting

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -43,6 +43,7 @@
         <activity
             android:name=".main.NeuroLab"
             android:label="@string/app_name"
+            android:launchMode="singleTop"
             android:theme="@style/AppTheme.Launcher">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/io/neurolab/main/NeuroLab.java
+++ b/app/src/main/java/io/neurolab/main/NeuroLab.java
@@ -274,7 +274,6 @@ public class NeuroLab extends AppCompatActivity
             startActivity(new Intent(this, DeviceInstructionsActivity.class));
         } else if (id == R.id.nav_settings) {
             startActivity(new Intent(this, SettingsActivity.class));
-            finish();
         } else if (id == R.id.nav_about_us) {
             startActivity(new Intent(this, AboutUsActivity.class));
         } else if (id == R.id.nav_share) {


### PR DESCRIPTION
Fixes #446  
**Changes**: I have made two changes. One in the Neurolab.java and other in the manifest.
Screenshots for the same are attached below.

**Screenshots for the changes:**  
1) [Neuro lab screenshot](https://drive.google.com/file/d/1ppx1Zz7q4kGsyoyZnVdBPpcgzKYRiHfh/view?usp=sharing)
I have removed the finish() line below line 276 -  startActivity(new Intent(this, SettingsActivity.class)); . This I have done to prevent the Neurolab Activity to get finished after Setting Activity has been called. 
2) [Manifest screenshot](https://drive.google.com/file/d/1aDPa6jPyAUIMd-UzjkmyLvKbljfYuy5N/view?usp=sharing)
I have added a line below line 46 - android:launchMode="singleTop" . This I have done to make the Neurolab Activity use the same instance when we click the back button on Setting Activity.

Android Launch mode guide: [Click here](https://medium.com/@iammert/android-launchmode-visualized-8843fc833dbe)

**Checklist**: 
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**: 
[Updated APK Link](https://drive.google.com/file/d/1-orHKqSOgmrSUWaox49U5DCJsGWledVp/view?usp=sharing
)