### PR TITLE
Fixed Meditation Bug

### DIFF
--- a/app/src/main/java/io/neurolab/fragments/ConfigFragment.java
+++ b/app/src/main/java/io/neurolab/fragments/ConfigFragment.java
@@ -5,6 +5,7 @@ import android.os.Bundle;
 import android.support.v7.preference.CheckBoxPreference;
 import android.support.v7.preference.Preference;
 import android.support.v7.preference.PreferenceFragmentCompat;
+import android.widget.Toast;
 
 import io.neurolab.R;
 import io.neurolab.main.NeuroLab;
@@ -42,8 +43,10 @@ public class ConfigFragment extends PreferenceFragmentCompat implements SharedPr
             case DEV_MODE_KEY:
                 if (!developerModeCheck.isChecked())
                     NeuroLab.developerMode = true;
-                else
+                else {
                     NeuroLab.developerMode = false;
+                    Toast.makeText(getActivity(), R.string.dev_mode_msg, Toast.LENGTH_SHORT).show();
+                }
                 break;
             default:
                 break;

--- a/app/src/main/java/io/neurolab/main/NeuroLab.java
+++ b/app/src/main/java/io/neurolab/main/NeuroLab.java
@@ -75,10 +75,12 @@ public class NeuroLab extends AppCompatActivity
     private static int baudRate = 9600;
     private static boolean deviceConnected;
     private static String deviceData;
-    private Menu menu;
-    private int launcherSleepTime;
     private static AppUpdateManager appUpdateManager;
     private static Task<AppUpdateInfo> appUpdateInfoTask;
+    private MenuItem navMeditate;
+    private Menu menu;
+    private CardView meditationCard;
+    private int launcherSleepTime;
     private UsbSerialInterface.UsbReadCallback readCallback = new UsbSerialInterface.UsbReadCallback() { //Defining a Callback which triggers whenever data is read.
         @Override
         public void onReceivedData(byte[] arg0) {
@@ -167,7 +169,7 @@ public class NeuroLab extends AppCompatActivity
         NavigationView navigationView = findViewById(R.id.nav_view);
         navigationView.setNavigationItemSelectedListener(this);
         Menu menuNav = navigationView.getMenu();
-        MenuItem navMeditate = menuNav.findItem(R.id.nav_meditation);
+        navMeditate = menuNav.findItem(R.id.nav_meditation);
 
         if (!developerMode)
             navMeditate.setVisible(false);
@@ -177,7 +179,7 @@ public class NeuroLab extends AppCompatActivity
         CardView focusButton = findViewById(R.id.focus_card);
         CardView relaxButton = findViewById(R.id.relax_card);
         CardView memGraphButton = findViewById(R.id.mem_graph_card);
-        CardView meditationCard = findViewById(R.id.meditation_card);
+        meditationCard = findViewById(R.id.meditation_card);
 
         focusButton.setOnClickListener(this);
         relaxButton.setOnClickListener(this);
@@ -214,6 +216,22 @@ public class NeuroLab extends AppCompatActivity
     @Override
     protected void onResume() {
         super.onResume();
+
+        SharedPreferences sharedPreferences =
+                PreferenceManager.getDefaultSharedPreferences(this);
+        developerMode = sharedPreferences.getBoolean(DEV_MODE_KEY, false);
+        if (developerMode) {
+            meditationCard.setVisibility(View.VISIBLE);
+            meditationCard.setOnClickListener(this);
+            navMeditate.setVisible(true);
+            invalidateOptionsMenu();
+        }
+
+        if (!developerMode) {
+            meditationCard.setVisibility(View.GONE);
+            navMeditate.setVisible(false);
+            invalidateOptionsMenu();
+        }
 
         appUpdateManager
                 .getAppUpdateInfo()
@@ -302,6 +320,12 @@ public class NeuroLab extends AppCompatActivity
 
             testMode.setVisible(false);
             bluetoothMode.setVisible(false);
+        } else {
+            MenuItem testMode = this.menu.findItem(R.id.test_mode);
+            MenuItem bluetoothMode = this.menu.findItem(R.id.bluetooth_test);
+
+            testMode.setVisible(true);
+            bluetoothMode.setVisible(true);
         }
         return true;
     }


### PR DESCRIPTION
Fixes #485 

**Changes**: Made changes in the settings activity to reload neurolab activity whenever user hits the back button from settings activity.

**Screenshot/s for the changes**: 
![MeditationBug](https://user-images.githubusercontent.com/38812752/65992591-1c7dea80-e4ad-11e9-972b-444803429868.gif)


**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**: 
[app-debug.zip](https://github.com/fossasia/neurolab-android/files/3678095/app-debug.zip)

