### PR TITLE
fix : Redundant views in Data Logger Screen.

### DIFF
--- a/app/src/main/java/io/neurolab/activities/DataLoggerActivity.java
+++ b/app/src/main/java/io/neurolab/activities/DataLoggerActivity.java
@@ -55,6 +55,7 @@ public class DataLoggerActivity extends AppCompatActivity {
     }
 
     private void showLoggedDataList(File appDir) {
+        clearRedundantFiles();
         File[] files = appDir.listFiles();
         if (appDir.listFiles() != null && files.length > 0) {
             noLoggedView.setVisibility(View.GONE);
@@ -84,6 +85,11 @@ public class DataLoggerActivity extends AppCompatActivity {
             dataloggerRecyclerView.setLayoutManager(linearLayoutManager);
             dataloggerRecyclerView.setAdapter(adapter);
         }
+    }
+
+    public void clearRedundantFiles() {
+        filesList.clear();
+        fileList.clear();
     }
 
     @Override


### PR DESCRIPTION
Fixes #503 

**Changes**:
Fixed redundant views in data logger screen.

**Screenshot/s for the changes**:
![ezgif com-optimize](https://user-images.githubusercontent.com/31280303/66856986-fcb5ee80-efa3-11e9-8cc9-38101d6eeaaf.gif)

**Checklist**: 
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**:
[apkDebug.zip](https://github.com/fossasia/neurolab-android/files/3730799/apkDebug.zip)

