### PR TITLE
feature : Add data share option from data logger screen.

### DIFF
--- a/app/src/main/java/io/neurolab/activities/DataLoggerActivity.java
+++ b/app/src/main/java/io/neurolab/activities/DataLoggerActivity.java
@@ -7,6 +7,8 @@ import android.os.Environment;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
+import android.view.Menu;
+import android.view.MenuItem;
 import android.view.View;
 import android.widget.TextView;
 import java.io.File;
@@ -84,6 +86,22 @@ public class DataLoggerActivity extends AppCompatActivity {
                     this, LinearLayoutManager.VERTICAL, false);
             dataloggerRecyclerView.setLayoutManager(linearLayoutManager);
             dataloggerRecyclerView.setAdapter(adapter);
+        }
+    }
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        getMenuInflater().inflate(R.menu.share_menu, menu);
+        return true;
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        switch (item.getItemId()) {
+            case R.id.share:
+                startActivity(new Intent(this,ShareDataActivity.class));
+            default:
+                return super.onOptionsItemSelected(item);
         }
     }
 

--- a/app/src/main/res/menu/share_menu.xml
+++ b/app/src/main/res/menu/share_menu.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/share"
+        android:icon="@android:drawable/ic_menu_share"
+        android:title="Share"
+        app:showAsAction="always"
+        app:actionProviderClass="android.support.v4.view.ActionProvider" />
+</menu>


### PR DESCRIPTION
Fixes #507 

**Changes**:
Added share option in the data logger screen

**Screenshot/s for the changes**:
![ezgif com-optimize](https://user-images.githubusercontent.com/31280303/67059189-b7491b00-f175-11e9-917b-5cbab9848589.gif)


**Checklist**:
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**:
[apkDebug.zip](https://github.com/fossasia/neurolab-android/files/3741888/apkDebug.zip)
