### PR TITLE
fix: App crash on back press to exit

### DIFF
--- a/app/src/main/java/io/neurolab/main/NeuroLab.java
+++ b/app/src/main/java/io/neurolab/main/NeuroLab.java
@@ -159,7 +159,7 @@ public class NeuroLab extends AppCompatActivity
         intentFilter = new IntentFilter();
         // adding the possible USB intent actions.
         intentFilter.addAction(ACTION_USB_PERMISSION);
-        registerReceiver(broadcastReceiver, intentFilter);
+
         appUpdateManager = AppUpdateManagerFactory.create(getApplicationContext());
         appUpdateInfoTask = appUpdateManager.getAppUpdateInfo();
 
@@ -220,6 +220,7 @@ public class NeuroLab extends AppCompatActivity
     protected void onResume() {
         super.onResume();
 
+        registerReceiver(broadcastReceiver, intentFilter);
         SharedPreferences sharedPreferences =
                 PreferenceManager.getDefaultSharedPreferences(this);
         developerMode = sharedPreferences.getBoolean(DEV_MODE_KEY, false);
@@ -270,7 +271,6 @@ public class NeuroLab extends AppCompatActivity
         if (drawer.isDrawerOpen(GravityCompat.START)) {
             drawer.closeDrawer(GravityCompat.START);
         } else {
-            unregisterReceiver(broadcastReceiver);
             if (mBackPressed + TIME_INTERVAL > System.currentTimeMillis()) {
                 super.onBackPressed();
                 return;
@@ -417,5 +417,12 @@ public class NeuroLab extends AppCompatActivity
                 break;
         }
     }
+
+    @Override
+    protected void onPause() {
+        super.onPause();
+        unregisterReceiver(broadcastReceiver);
+    }
+
 
 }


### PR DESCRIPTION
Fixes #526 

**Changes**:

Added try catch block to prevent the crash.

**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**: 

[feature.zip](https://github.com/fossasia/neurolab-android/files/3828766/feature.zip)

