### PR TITLE
fix: #538 Add unregisterReceiver() missing in some fragments

### DIFF
--- a/app/src/main/java/io/neurolab/fragments/FocusVisualFragment.java
+++ b/app/src/main/java/io/neurolab/fragments/FocusVisualFragment.java
@@ -76,6 +76,7 @@ public class FocusVisualFragment extends android.support.v4.app.Fragment {
             Manifest.permission.READ_EXTERNAL_STORAGE
     };
     public static final String FOCUS_FLAG = "Focus";
+    private boolean isReceiverRegistered = false;
 
     private SpaceAnimationVisuals rocketAnimation;
     private View view;
@@ -194,6 +195,7 @@ public class FocusVisualFragment extends android.support.v4.app.Fragment {
         // adding the possible USB intent actions.
         intentFilter.addAction(ACTION_USB_PERMISSION);
         getContext().registerReceiver(dataReceiver, intentFilter);
+        isReceiverRegistered = true;
 
         usbCommunicationHandler.searchForArduinoDevice(getContext());
         locationTracker.startCaptureLocation();
@@ -324,6 +326,13 @@ public class FocusVisualFragment extends android.support.v4.app.Fragment {
     @Override
     public void onResume() {
         super.onResume();
+        IntentFilter intentFilter = new IntentFilter();
+        // adding the possible USB intent actions.
+        intentFilter.addAction(ACTION_USB_PERMISSION);
+        if (dataReceiver != null && !isReceiverRegistered) {
+            getContext().registerReceiver(dataReceiver, intentFilter);
+            isReceiverRegistered = true;
+        }
     }
 
     @Override
@@ -333,6 +342,10 @@ public class FocusVisualFragment extends android.support.v4.app.Fragment {
         extractedData = null;
         freq = null;
         SpaceAnimationVisuals.count = 0;
+        if (dataReceiver != null && isReceiverRegistered) {
+            getContext().unregisterReceiver(dataReceiver);
+            isReceiverRegistered = false;
+        }
     }
 
     @Override

--- a/app/src/main/java/io/neurolab/fragments/MemoryGraphFragment.java
+++ b/app/src/main/java/io/neurolab/fragments/MemoryGraphFragment.java
@@ -81,6 +81,8 @@ public class MemoryGraphFragment extends Fragment implements OnChartValueSelecte
     private float maxEEGValue = 9000f;
     private float effectiveDistance = 30f;
     private boolean permission = false;
+    private boolean isReceiverRegistered = false;
+
     private static final String[] READ_WRITE_PERMISSIONS = {
             Manifest.permission.WRITE_EXTERNAL_STORAGE,
             Manifest.permission.READ_EXTERNAL_STORAGE
@@ -324,11 +326,22 @@ public class MemoryGraphFragment extends Fragment implements OnChartValueSelecte
         if (thread != null) {
             thread.interrupt();
         }
+        if (dataReceiver != null && isReceiverRegistered) {
+            getContext().unregisterReceiver(dataReceiver);
+            isReceiverRegistered = false;
+        }
     }
 
     @Override
     public void onResume() {
         super.onResume();
+        IntentFilter intentFilter = new IntentFilter();
+        // adding the possible USB intent actions.
+        intentFilter.addAction(ACTION_USB_PERMISSION);
+        if (dataReceiver != null && !isReceiverRegistered){
+            getContext().registerReceiver(dataReceiver, intentFilter);
+            isReceiverRegistered = true;
+        }
     }
 
     @Override
@@ -398,6 +411,8 @@ public class MemoryGraphFragment extends Fragment implements OnChartValueSelecte
         // adding the possible USB intent actions.
         intentFilter.addAction(ACTION_USB_PERMISSION);
         getContext().registerReceiver(dataReceiver, intentFilter);
+        isReceiverRegistered = true;
+
         usbCommunicationHandler.searchForArduinoDevice(getContext());
         locationTracker.startCaptureLocation();
         if (usbCommunicationHandler.getSerialPort() != null) {


### PR DESCRIPTION
Fixes: #538 Add unregisterReceiver() missing in some fragments

**Changes**: unregisterReceiver() is added to MemoryGraphFragment and FocusVisualFragment

**Checklist**:
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

