### PR TITLE
fix : Display message when no files on device.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,7 +23,8 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
         tools:ignore="AllowBackup">
-        <activity android:name=".activities.ShareDataActivity" />
+        <activity android:name=".activities.ShareDataActivity"
+            android:label="Share"/>
         <activity android:name=".activities.RelaxParentActivity" />
         <activity android:name=".activities.PinLayoutActivity" />
         <activity android:name=".activities.MeditationListActivity" />

--- a/app/src/main/java/io/neurolab/activities/DataLoggerActivity.java
+++ b/app/src/main/java/io/neurolab/activities/DataLoggerActivity.java
@@ -67,12 +67,13 @@ public class DataLoggerActivity extends AppCompatActivity {
                 filesList.add(file);
             }
             DataLoggerListAdapter adapter = new DataLoggerListAdapter(this, filesList, flag);
+            checkAdapterStateChanged(adapter);
             LinearLayoutManager linearLayoutManager = new LinearLayoutManager(
                     this, LinearLayoutManager.VERTICAL, false);
             dataloggerRecyclerView.setLayoutManager(linearLayoutManager);
             dataloggerRecyclerView.setAdapter(adapter);
-        } else {
-
+        }
+        else {
             setupPath();
             noLoggedView.setVisibility(View.GONE);
 
@@ -82,11 +83,40 @@ public class DataLoggerActivity extends AppCompatActivity {
             readWriteData("sample4", appDir);
 
             DataLoggerListAdapter adapter = new DataLoggerListAdapter(this, filesList, flag);
+            checkAdapterStateChanged(adapter);
             LinearLayoutManager linearLayoutManager = new LinearLayoutManager(
                     this, LinearLayoutManager.VERTICAL, false);
             dataloggerRecyclerView.setLayoutManager(linearLayoutManager);
             dataloggerRecyclerView.setAdapter(adapter);
         }
+    }
+
+    public void checkAdapterStateChanged(DataLoggerListAdapter adapter){
+        adapter.registerAdapterDataObserver(new RecyclerView.AdapterDataObserver() {
+
+            @Override
+            public void onChanged() {
+                super.onChanged();
+                checkEmpty();
+            }
+
+            @Override
+            public void onItemRangeInserted(int positionStart, int itemCount) {
+                super.onItemRangeInserted(positionStart, itemCount);
+                checkEmpty();
+            }
+
+            @Override
+            public void onItemRangeRemoved(int positionStart, int itemCount) {
+                super.onItemRangeRemoved(positionStart, itemCount);
+                checkEmpty();
+            }
+
+            void checkEmpty() {
+                noLoggedView.setVisibility(adapter.getItemCount() == 0 ? View.VISIBLE : View.GONE);
+            }
+        });
+
     }
 
     @Override

--- a/app/src/main/java/io/neurolab/activities/ShareDataActivity.java
+++ b/app/src/main/java/io/neurolab/activities/ShareDataActivity.java
@@ -14,7 +14,9 @@ import android.util.SparseBooleanArray;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
+import android.widget.Button;
 import android.widget.ListView;
+import android.widget.TextView;
 import android.widget.Toast;
 import java.io.File;
 import java.util.ArrayList;
@@ -39,6 +41,8 @@ public class ShareDataActivity extends AppCompatActivity {
     private static ArrayList<Uri> selectedUri = new ArrayList<Uri>();
     private static Set<Uri> set;
     private static SparseBooleanArray sparseBooleanArray;
+    private static TextView numberOfFiles;
+    private static Button shareButton;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -46,9 +50,10 @@ public class ShareDataActivity extends AppCompatActivity {
         setContentView(R.layout.activity_share_data);
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
 
-        Toast.makeText(this, R.string.share_screen_toast, Toast.LENGTH_SHORT).show();
 
         fileListView = findViewById(R.id.fileListView);
+        shareButton = findViewById(R.id.share_btn);
+        numberOfFiles = findViewById(R.id.fileNumberView);
         context = getApplicationContext();
 
         resultIntent = new Intent(Intent.ACTION_SEND_MULTIPLE);
@@ -70,6 +75,14 @@ public class ShareDataActivity extends AppCompatActivity {
                 newFileName[i] = files[i].getName();
                 j++;
             }
+            numberOfFiles.setVisibility(View.INVISIBLE);
+            Toast.makeText(this, R.string.share_screen_toast, Toast.LENGTH_SHORT).show();
+        }
+
+        if (appDir.listFiles().length == 0) {
+            numberOfFiles.setVisibility(View.VISIBLE);
+            numberOfFiles.setText(R.string.no_datasets_message);
+            shareButton.setVisibility(View.INVISIBLE);
         }
 
         final List<String> file_list = new ArrayList<String>(Arrays.asList(newFileName));

--- a/app/src/main/res/layout/activity_share_data.xml
+++ b/app/src/main/res/layout/activity_share_data.xml
@@ -34,9 +34,18 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_above="@+id/linear_layout"
+        android:layout_below="@+id/fileNumberView"
         android:layout_alignParentStart="true"
-        android:layout_alignParentTop="true"
         android:layout_marginTop="@dimen/layout_margin_medium"
         android:layout_marginBottom="@dimen/layout_margin_medium" />
+
+    <TextView
+        android:id="@+id/fileNumberView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentTop="true"
+        android:layout_marginTop="@dimen/layout_margin_medium"
+        android:textAlignment="center"
+        android:textSize="@dimen/text_size_larger" />
 
 </RelativeLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -174,6 +174,7 @@ A difference to existing projects like OpenBCI is that it will not be necessary 
     <string name="meditation">Meditate</string>
     <string name="meditation_desc">to (cause someone to) become less active and more calm and happy</string>
     <string name="title_activity_share">ShareActivity</string>
+    <string name="no_datasets_message">No files to show</string>
     <string name="enable">Enable</string>
     <string name="received_data_display">received data display</string>
     <string name="send">Send</string>


### PR DESCRIPTION
Fixes #533 

**Changes**:
Show message in Share Data activity in case there are no datasets on the device.

**Screenshot/s for the changes**: 

**Screenshot**
![20191128_122525-min](https://user-images.githubusercontent.com/31280303/69784112-02c20080-11db-11ea-988d-756312a0c2ed.gif)

**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing (Latest)**: 
[apkDebug.zip](https://github.com/fossasia/neurolab-android/files/3900322/apkDebug.zip)


