### PR TITLE
Display track name in meditation activity.

### DIFF
--- a/app/src/main/java/io/neurolab/activities/MeditationActivity.java
+++ b/app/src/main/java/io/neurolab/activities/MeditationActivity.java
@@ -5,6 +5,7 @@ import android.os.Bundle;
 import android.support.v4.media.session.PlaybackStateCompat;
 import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
+import android.util.TypedValue;
 import android.widget.SeekBar;
 import android.widget.TextView;
 
@@ -25,6 +26,7 @@ public final class MeditationActivity extends AppCompatActivity {
     private SeekBar seekbarAudio;
     private TextView progressTimeView;
     private TextView durationView;
+    private TextView trackNameView;
 
     // the interface reference which would be used to control the media session from this UI client.
     private PlayerAdapter playerAdapter;
@@ -40,6 +42,8 @@ public final class MeditationActivity extends AppCompatActivity {
         MEDIA_RES_ID = getIntent().getIntExtra(MEDITATION_DIR_KEY, R.raw.soften_and_relax);
 
         grabNecessaryReferencesAndSetListeners();
+
+        setTrackName(MEDIA_RES_ID);
 
         initializePlaybackController();
     }
@@ -70,6 +74,7 @@ public final class MeditationActivity extends AppCompatActivity {
         seekbarAudio = findViewById(R.id.seekbar_audio);
         progressTimeView = findViewById(R.id.progress_time);
         durationView = findViewById(R.id.duration_view);
+        trackNameView = findViewById(R.id.track_name);
 
         pauseButton.setOnClickListener(
                 view -> playerAdapter.pause());
@@ -79,6 +84,33 @@ public final class MeditationActivity extends AppCompatActivity {
                 view -> playerAdapter.reset());
 
         setSeekbarListener();
+    }
+
+    private void setTrackName(int MEDIA_RES_ID) {
+        TypedValue value = new TypedValue();
+        getResources().getValue(MEDIA_RES_ID, value, true);
+        String trackName = getMeditationName(getName(value.string.toString()));
+        trackNameView.setText(trackName);
+    }
+
+    private String getName(String path) {
+        String[] token = path.split("/raw/", 2);
+        String[] nextToken = token[1].split(".mp3", 2);
+        String finalName = nextToken[0];
+        return finalName;
+    }
+
+    private String getMeditationName(String rawName) {
+        String name = "" + rawName.charAt(0);
+        name = name.toUpperCase();
+        for (int i = 1; i < rawName.length(); i++) {
+            if (rawName.charAt(i) == '_') {
+                name += ' ';
+                continue;
+            }
+            name += rawName.charAt(i);
+        }
+        return name;
     }
 
     private void initializePlaybackController() {

--- a/app/src/main/res/layout-land/activity_meditation.xml
+++ b/app/src/main/res/layout-land/activity_meditation.xml
@@ -32,7 +32,15 @@
             android:text="@string/default_timer"
             android:textColor="@color/colorPrimary"
             android:textSize="@dimen/text_size_larger" />
-        
+
+        <TextView
+            android:id="@+id/track_name"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:textSize="@dimen/text_size_larger"
+            android:textColor="@color/focus_screen_bg"/>
+
         <TextView
             android:id="@+id/duration_view"
             android:layout_width="wrap_content"

--- a/app/src/main/res/layout/activity_meditation.xml
+++ b/app/src/main/res/layout/activity_meditation.xml
@@ -26,8 +26,15 @@
         android:layout_margin="@dimen/layout_margin_medium"
         android:layout_gravity="center"/>
 
+    <TextView
+        android:id="@+id/track_name"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textSize="@dimen/text_size_larger"
+        android:textColor="@color/focus_screen_bg"
+        android:layout_gravity="center" />
 
-        <TextView
+    <TextView
             android:id="@+id/duration_view"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"


### PR DESCRIPTION
Fixes #543 

**Changes**: 
Name of the track currently being played is shown in the meditation Activity.

**GIF for the changes**: 
![ezgif com-optimize](https://user-images.githubusercontent.com/31280303/69897022-f1f4c480-136b-11ea-8e58-32affdd5690c.gif)


**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**: 
[apkDebug.zip](https://github.com/fossasia/neurolab-android/files/3906812/apkDebug.zip)
