### PR TITLE
setting orientation issue

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -62,7 +62,8 @@
         </activity>
         <activity
             android:name=".activities.SettingsActivity"
-            android:parentActivityName=".main.NeuroLab" />
+            android:parentActivityName=".main.NeuroLab"
+            android:configChanges="orientation|keyboardHidden"/>
         <activity
             android:name=".activities.OnBoardingActivity"
             android:theme="@style/AppTheme.NoActionBar" />


### PR DESCRIPTION
Fixes #556 

**Changes**: The recreation of settings activity on the orientation change is handled.

**Screenshot/s for the changes**: 

>>The app is not crashing when developer option is checked/unchecked in other orientation. Also not recreating the activity every time the orientation changes retains the previously marked checkboxes.

![WhatsAppVideo2020-01-03at110427A](https://user-images.githubusercontent.com/38812752/71708753-48e13400-2e19-11ea-9af0-20f5c8aad951.gif)

**Checklist**: 
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**: 
[app-debug-new.zip](https://github.com/fossasia/neurolab-android/files/4018190/app-debug-new.zip)

