### PR TITLE
NeuroSettingsFragment bug

### DIFF
--- a/app/src/main/java/io/neurolab/fragments/NeuroSettingsFragment.java
+++ b/app/src/main/java/io/neurolab/fragments/NeuroSettingsFragment.java
@@ -8,9 +8,9 @@ import android.view.KeyEvent;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import com.takisoft.fix.support.v7.preference.EditTextPreference;
-
 import com.takisoft.fix.support.v7.preference.PreferenceFragmentCompat;
 
 import io.neurolab.R;
@@ -40,6 +40,19 @@ public class NeuroSettingsFragment extends PreferenceFragmentCompat implements S
 
     @Override
     public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
+
+        if (samplesPref.getText().isEmpty()) {
+            samplesPref.setText("3");
+            Toast.makeText(getActivity(), "Enter valid input !", Toast.LENGTH_SHORT).show();
+        }
+        if (binsPref.getText().isEmpty()) {
+            binsPref.setText("4");
+            Toast.makeText(getActivity(), "Enter valid input !", Toast.LENGTH_SHORT).show();
+        }
+        if (channelsPref.getText().isEmpty()) {
+            channelsPref.setText("2");
+            Toast.makeText(getActivity(), "Enter valid input !", Toast.LENGTH_SHORT).show();
+        }
         switch (key) {
             // TODO: Set limits to following preferences
             case KEY_SAMPLES:
@@ -91,7 +104,7 @@ public class NeuroSettingsFragment extends PreferenceFragmentCompat implements S
 
     @Override
     public boolean onEditorAction(TextView v, int actionId, KeyEvent event) {
-        if(actionId == EditorInfo.IME_ACTION_DONE){
+        if (actionId == EditorInfo.IME_ACTION_DONE) {
             InputMethodManager imm = (InputMethodManager) v.getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
             imm.hideSoftInputFromWindow(v.getWindowToken(), 0);
             return true;


### PR DESCRIPTION
Fixes #560 

**Changes**: The changes are made in the NeuroSettingsFragment , where a the toast is initiated whenever the EditTextPreference is given a null value.

**Screenshot/s for the changes**: 
![WhatsAppVideo2020-01-04at41233PM](https://user-images.githubusercontent.com/38812752/71957128-ede17f80-3212-11ea-8953-f406dbd08341.gif)

**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**: 
[app-debug-new.zip](https://github.com/fossasia/neurolab-android/files/4033955/app-debug-new.zip)

