### PR TITLE
Fixes #572 Removes unnecessary developer mode toast from main activity

### DIFF
--- a/app/src/main/java/io/neurolab/main/NeuroLab.java
+++ b/app/src/main/java/io/neurolab/main/NeuroLab.java
@@ -75,6 +75,7 @@ public class NeuroLab extends AppCompatActivity
     private static UsbManager usbManager;
     private static int baudRate = 9600;
     private static boolean deviceConnected;
+    private static boolean devmode_toast_flag = true;
     private static String deviceData;
     private static AppUpdateManager appUpdateManager;
     private static Task<AppUpdateInfo> appUpdateInfoTask;
@@ -139,8 +140,11 @@ public class NeuroLab extends AppCompatActivity
         SharedPreferences sharedPreferences =
                 PreferenceManager.getDefaultSharedPreferences(this);
         developerMode = sharedPreferences.getBoolean(DEV_MODE_KEY, false);
-        if (developerMode)
-            Toast.makeText(this, R.string.dev_mode_msg, Toast.LENGTH_SHORT).show();
+        if(devmode_toast_flag) {
+            if (developerMode)
+                Toast.makeText(this, R.string.dev_mode_msg, Toast.LENGTH_SHORT).show();
+        devmode_toast_flag = false;
+        }
         // Check if we need to display our OnBoardingActivity
         if (!sharedPreferences.getBoolean(
                 OnBoardingActivity.getOnBoardingPrefKey(), false)) {


### PR DESCRIPTION
Fixes #572 

**Changes**: 
Shows Developer mode enabled toast only when the application starts and not on orientation change or on returning from another activity. Created a flag variable to do so. 

**Screenshot/s for the changes**: 
![20200118_115924](https://user-images.githubusercontent.com/18425237/72659747-9ef1d200-39ea-11ea-9e62-ce6c2d0e370f.gif)

**Checklist**: 
- [ x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [ x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [ x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [ x] My code does not contain any extra lines or extra spaces
- [ x] I have requested reviews from other members

**APK for testing**: 
[feature.zip](https://github.com/fossasia/neurolab-android/files/4080078/feature.zip)
