### PR TITLE
text overflow on home page fixed

### DIFF
--- a/app/src/main/res/layout/card_focus.xml
+++ b/app/src/main/res/layout/card_focus.xml
@@ -44,7 +44,7 @@
 
             <LinearLayout
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
+                android:layout_height="match_parent"
                 android:layout_weight="1"
                 android:orientation="vertical">
 

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -110,7 +110,7 @@
     <dimen name="meditate_avatar_size">40dp</dimen>
     <dimen name="card_main_margin_lr">10dp</dimen>
     <dimen name="card_main_margin_tb">5dp</dimen>
-    <dimen name="card_main_layout_padding">16dp</dimen>
+    <dimen name="card_main_layout_padding">10dp</dimen>
     <dimen name="image_main_layout_margin">8dp</dimen>
     <dimen name="main_content_padding_textview">12dp</dimen>
 


### PR DESCRIPTION
Fixes #546 

**Changes**: Complete text appears now.

**Screenshot/s for the changes**: 
![NeuroLab_fixed](https://user-images.githubusercontent.com/37077735/72595139-28dc6500-392f-11ea-8083-1f7b15636307.jpg)


**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**: 
[text-fixed.zip](https://github.com/fossasia/neurolab-android/files/4075681/text-fixed.zip)
