### PR TITLE
text overflow on meditate home fixed

### DIFF
--- a/app/src/main/res/layout/activity_meditation_home.xml
+++ b/app/src/main/res/layout/activity_meditation_home.xml
@@ -25,17 +25,11 @@
             android:layout_marginStart="@dimen/layout_margin_medium"
             android:layout_marginTop="@dimen/layout_margin_medium" />
 
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal">
-
             <android.support.v7.widget.CardView
                 android:id="@+id/happy_card"
-                android:layout_width="@dimen/spacing_none"
+                android:layout_width="match_parent"
                 android:layout_height="@dimen/bin_image_margin_top"
                 android:layout_margin="@dimen/layout_margin_medium"
-                android:layout_weight="1"
                 app:cardCornerRadius="@dimen/card_main_corner"
                 app:cardElevation="@dimen/card_main_elevation"
                 app:cardPreventCornerOverlap="false">
@@ -61,6 +55,7 @@
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_marginStart="@dimen/layout_margin_medium"
+                            android:layout_marginTop="@dimen/layout_margin_medium"
                             android:orientation="vertical">
 
                             <TextView
@@ -84,10 +79,9 @@
 
             <android.support.v7.widget.CardView
                 android:id="@+id/depression_card"
-                android:layout_width="@dimen/spacing_none"
+                android:layout_width="match_parent"
                 android:layout_height="@dimen/bin_image_margin_top"
                 android:layout_margin="@dimen/layout_margin_medium"
-                android:layout_weight="1"
                 app:cardCornerRadius="@dimen/card_main_corner"
                 app:cardElevation="@dimen/card_main_elevation"
                 app:cardPreventCornerOverlap="false">
@@ -113,7 +107,8 @@
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_marginStart="@dimen/layout_margin_medium"
-                            android:orientation="vertical">
+                            android:orientation="vertical"
+                            android:layout_marginTop="@dimen/layout_margin_medium">
 
                             <TextView
                                 android:layout_width="match_parent"
@@ -133,19 +128,12 @@
                 </RelativeLayout>
 
             </android.support.v7.widget.CardView>
-        </LinearLayout>
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal">
 
             <android.support.v7.widget.CardView
                 android:id="@+id/sleep_card"
-                android:layout_width="@dimen/spacing_none"
+                android:layout_width="match_parent"
                 android:layout_height="@dimen/bin_image_margin_top"
                 android:layout_margin="@dimen/layout_margin_medium"
-                android:layout_weight="1"
                 app:cardCornerRadius="@dimen/card_main_corner"
                 app:cardElevation="@dimen/card_main_elevation"
                 app:cardPreventCornerOverlap="false">
@@ -171,6 +159,7 @@
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_marginStart="@dimen/layout_margin_medium"
+                            android:layout_marginTop="@dimen/layout_margin_medium"
                             android:orientation="vertical">
 
                             <TextView
@@ -186,7 +175,6 @@
                                 android:text="@string/sleep_desc" />
                         </LinearLayout>
 
-
                     </LinearLayout>
 
                 </RelativeLayout>
@@ -195,10 +183,9 @@
 
             <android.support.v7.widget.CardView
                 android:id="@+id/travel_card"
-                android:layout_width="@dimen/spacing_none"
+                android:layout_width="match_parent"
                 android:layout_height="@dimen/bin_image_margin_top"
                 android:layout_margin="@dimen/layout_margin_medium"
-                android:layout_weight="1"
                 app:cardCornerRadius="@dimen/card_main_corner"
                 app:cardElevation="@dimen/card_main_elevation"
                 app:cardPreventCornerOverlap="false">
@@ -224,6 +211,7 @@
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_marginStart="@dimen/layout_margin_medium"
+                            android:layout_marginTop="@dimen/layout_margin_medium"
                             android:orientation="vertical">
 
                             <TextView
@@ -244,19 +232,12 @@
                 </RelativeLayout>
 
             </android.support.v7.widget.CardView>
-        </LinearLayout>
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal">
 
             <android.support.v7.widget.CardView
                 android:id="@+id/sh_break_card"
-                android:layout_width="@dimen/spacing_none"
+                android:layout_width="match_parent"
                 android:layout_height="@dimen/layout_margin_huge"
                 android:layout_margin="@dimen/layout_margin_medium"
-                android:layout_weight="1"
                 app:cardCornerRadius="@dimen/card_main_corner"
                 app:cardElevation="@dimen/card_main_elevation"
                 app:cardPreventCornerOverlap="false">
@@ -282,6 +263,7 @@
                         <LinearLayout
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
+                            android:layout_marginTop="@dimen/layout_margin_medium"
                             android:layout_marginStart="@dimen/layout_margin_medium"
                             android:orientation="vertical">
 
@@ -306,10 +288,9 @@
 
             <android.support.v7.widget.CardView
                 android:id="@+id/lg_break_card"
-                android:layout_width="@dimen/spacing_none"
+                android:layout_width="match_parent"
                 android:layout_height="@dimen/layout_margin_huge"
                 android:layout_margin="@dimen/layout_margin_medium"
-                android:layout_weight="1"
                 app:cardCornerRadius="@dimen/card_main_corner"
                 app:cardElevation="@dimen/card_main_elevation"
                 app:cardPreventCornerOverlap="false">
@@ -335,6 +316,7 @@
                         <LinearLayout
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
+                            android:layout_marginTop="@dimen/layout_margin_medium"
                             android:layout_marginStart="@dimen/layout_margin_medium"
                             android:orientation="vertical">
 
@@ -356,7 +338,7 @@
                 </RelativeLayout>
 
             </android.support.v7.widget.CardView>
-        </LinearLayout>
+
 
     </LinearLayout>
 </ScrollView>


### PR DESCRIPTION
Fixes #566 

**Changes**: Text overflow problem fixed. Layout changed to cover entire screen.

**Screenshot/s for the changes**: 
![NeuroLabfixed](https://user-images.githubusercontent.com/37077735/72613626-132e6600-3956-11ea-9643-904ff996e6e0.jpg)


**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**: 
[meditate.zip](https://github.com/fossasia/neurolab-android/files/4076839/meditate.zip)

