### PR TITLE
fix: Input of large values in setting

### DIFF
--- a/app/src/main/java/io/neurolab/fragments/NeuroSettingsFragment.java
+++ b/app/src/main/java/io/neurolab/fragments/NeuroSettingsFragment.java
@@ -57,15 +57,15 @@ public class NeuroSettingsFragment extends PreferenceFragmentCompat implements S
             // TODO: Set limits to following preferences
             case KEY_SAMPLES:
                 samplesPref.setSummary(samplesPref.getText() + " sample" +
-                        pluralize(Integer.valueOf(samplesPref.getText())));
+                        pluralize(samplesPref.getText()));
                 break;
             case KEY_BINS:
                 binsPref.setSummary(binsPref.getText() + " bin" +
-                        pluralize(Integer.valueOf(binsPref.getText())));
+                        pluralize(binsPref.getText()));
                 break;
             case KEY_CHANNELS:
                 channelsPref.setSummary(channelsPref.getText() + " channel" +
-                        pluralize(Integer.valueOf(channelsPref.getText())));
+                        pluralize(channelsPref.getText()));
                 break;
             default:
                 break;
@@ -91,15 +91,15 @@ public class NeuroSettingsFragment extends PreferenceFragmentCompat implements S
     public void onResume() {
         super.onResume();
         samplesPref.setSummary(samplesPref.getText() + " sample" +
-                pluralize(Integer.valueOf(samplesPref.getText())));
+                pluralize(samplesPref.getText()));
         binsPref.setSummary(binsPref.getText() + " bin" +
-                pluralize(Integer.valueOf(binsPref.getText())));
+                pluralize(binsPref.getText()));
         channelsPref.setSummary(channelsPref.getText() + " channel" +
-                pluralize(Integer.valueOf(channelsPref.getText())));
+                pluralize(channelsPref.getText()));
     }
 
-    private String pluralize(int count) {
-        return count > 1 ? "s" : "";
+    private String pluralize(String text) {
+        return (text.equals("0") || text.equals("1")) ? "" : "s";
     }
 
     @Override

--- a/app/src/main/java/io/neurolab/fragments/NeuroSettingsFragment.java
+++ b/app/src/main/java/io/neurolab/fragments/NeuroSettingsFragment.java
@@ -99,7 +99,7 @@ public class NeuroSettingsFragment extends PreferenceFragmentCompat implements S
     }
 
     private String pluralize(String text) {
-        return (text.equals("0") || text.equals("1")) ? "" : "s";
+        return ("0".equals(text) || "1".equals(text)) ? "" : "s";
     }
 
     @Override


### PR DESCRIPTION
Fixes #601 App Crash on Entering Large Values in Setting

**Changes**: 
Make the changes for the parse value

**Screenshot/s for the changes**: 
![neuro_solve_setting_crash](https://user-images.githubusercontent.com/44086235/73064206-b3d8d480-3ec6-11ea-8bb9-655d3c67d22e.gif)


**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members


