### PR TITLE
Fixes #604 Handles orientation change in Memory Graph Activity

### DIFF
--- a/app/src/main/java/io/neurolab/activities/MemoryGraphParent.java
+++ b/app/src/main/java/io/neurolab/activities/MemoryGraphParent.java
@@ -17,6 +17,7 @@ public class MemoryGraphParent extends AppCompatActivity {
 
     private String filePath;
     public static final String MEMORY_GRAPH_FLAG = "Memory";
+    private static Fragment defaultProgram = MemoryGraphFragment.newInstance();
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -49,12 +50,11 @@ public class MemoryGraphParent extends AppCompatActivity {
             selectedFragment.setArguments(bundle);
             FragmentTransaction transaction = getSupportFragmentManager().beginTransaction();
             transaction.replace(R.id.frame_layout, selectedFragment);
+            defaultProgram = selectedFragment;
             transaction.commit();
             return true;
         });
-
         FragmentTransaction transaction = getSupportFragmentManager().beginTransaction();
-        Fragment defaultProgram = MemoryGraphFragment.newInstance();
         defaultProgram.setArguments(bundle);
         transaction.replace(R.id.frame_layout, defaultProgram);
         transaction.commit();
@@ -70,6 +70,7 @@ public class MemoryGraphParent extends AppCompatActivity {
     public void onBackPressed() {
         super.onBackPressed();
         StatisticsFragment.parsedData = null;
+        defaultProgram = MemoryGraphFragment.newInstance();
     }
 
     public void setActionBarTitle(String title) {

--- a/app/src/main/res/layout/fragment_spectrum.xml
+++ b/app/src/main/res/layout/fragment_spectrum.xml
@@ -15,61 +15,66 @@
         android:textColor="@android:color/white"
         android:textSize="@dimen/text_size_small" />
 
-    <LinearLayout
+    <ScrollView
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:background="@color/memory_graph_background"
-        android:orientation="vertical">
-
-        <com.github.mikephil.charting.charts.LineChart
-            android:id="@+id/frequency_spectrum_chart"
-            android:layout_width="match_parent"
-            android:layout_height="@dimen/spectrum_screen_height"
-            android:background="@color/memory_graph_background">
-
-        </com.github.mikephil.charting.charts.LineChart>
+        android:background="@color/memory_graph_background">
 
         <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_margin="@dimen/padding_medium"
-            android:orientation="horizontal">
+            android:layout_height="match_parent"
+            android:background="@color/memory_graph_background"
+            android:orientation="vertical">
 
-            <ImageView
-                android:layout_width="@dimen/card_margin_large"
-                android:layout_height="@dimen/card_margin_large"
-                android:src="@android:color/holo_red_dark" />
+            <com.github.mikephil.charting.charts.LineChart
+                android:id="@+id/frequency_spectrum_chart"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/spectrum_screen_height"
+                android:background="@color/memory_graph_background">
 
-            <TextView
-                android:layout_width="wrap_content"
+            </com.github.mikephil.charting.charts.LineChart>
+
+            <LinearLayout
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginLeft="@dimen/padding_small"
-                android:text="@string/anger_range"
-                android:textSize="@dimen/text_size_small"
-                android:textColor="@android:color/white" />
+                android:layout_margin="@dimen/padding_medium"
+                android:orientation="horizontal">
 
-        </LinearLayout>
+                <ImageView
+                    android:layout_width="@dimen/card_margin_large"
+                    android:layout_height="@dimen/card_margin_large"
+                    android:src="@android:color/holo_red_dark" />
 
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_margin="@dimen/padding_medium"
-            android:orientation="horizontal">
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginLeft="@dimen/padding_small"
+                    android:text="@string/anger_range"
+                    android:textColor="@android:color/white"
+                    android:textSize="@dimen/text_size_small" />
 
-            <ImageView
-                android:layout_width="@dimen/card_margin_large"
-                android:layout_height="@dimen/card_margin_large"
-                android:src="@color/calm_green" />
+            </LinearLayout>
 
-            <TextView
-                android:layout_width="wrap_content"
+            <LinearLayout
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginLeft="@dimen/padding_small"
-                android:text="@string/calm_range"
-                android:textSize="@dimen/text_size_small"
-                android:textColor="@android:color/white" />
+                android:layout_margin="@dimen/padding_medium"
+                android:orientation="horizontal">
 
+                <ImageView
+                    android:layout_width="@dimen/card_margin_large"
+                    android:layout_height="@dimen/card_margin_large"
+                    android:src="@color/calm_green" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginLeft="@dimen/padding_small"
+                    android:text="@string/calm_range"
+                    android:textColor="@android:color/white"
+                    android:textSize="@dimen/text_size_small" />
+
+            </LinearLayout>
         </LinearLayout>
-    </LinearLayout>
-
+    </ScrollView>
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_statistics.xml
+++ b/app/src/main/res/layout/fragment_statistics.xml
@@ -7,6 +7,12 @@
     android:layout_height="match_parent"
     tools:context=".fragments.StatisticsFragment">
 
-    <include layout="@layout/stat_items" />
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <include layout="@layout/stat_items" />
+
+    </ScrollView>
 
 </android.support.constraint.ConstraintLayout>


### PR DESCRIPTION
Fixes #604 

**Changes**:
Handled Orientation change in Memory Graph activity .Now the slected fragment is retained after orientation change.

**Screenshot/s for the changes**:
![20200126_222945](https://user-images.githubusercontent.com/18425237/73138836-55118780-408d-11ea-9c38-5c0e7b8bf29d.gif)


**Checklist**:
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**:
[feature.zip](https://github.com/fossasia/neurolab-android/files/4113817/feature.zip) 