### PR TITLE
fix: Listener unregistered before leaving the ConfigFragement

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -63,7 +63,7 @@
         <activity
             android:name=".activities.SettingsActivity"
             android:parentActivityName=".main.NeuroLab"
-            android:configChanges="orientation|keyboardHidden"/>
+            android:configChanges="orientation|keyboardHidden|screenSize"/>
         <activity
             android:name=".activities.OnBoardingActivity"
             android:theme="@style/AppTheme.NoActionBar" />

--- a/app/src/main/java/io/neurolab/fragments/ConfigFragment.java
+++ b/app/src/main/java/io/neurolab/fragments/ConfigFragment.java
@@ -29,7 +29,18 @@ public class ConfigFragment extends PreferenceFragmentCompat implements SharedPr
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         developerModeCheck.setOnPreferenceChangeListener(this);
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
         sharedPreferences.registerOnSharedPreferenceChangeListener(this);
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        sharedPreferences.unregisterOnSharedPreferenceChangeListener(this);
     }
 
     @Override


### PR DESCRIPTION
Fixes #606 

**Changes**: I have attached the listener in the onResume( ) and also added the code to unregister the listener before leaving the ConfigFragment. 

**Screenshot/s for the changes**: 
![WhatsAppVideo2020-01-28at73850PM](https://user-images.githubusercontent.com/38812752/73271185-22d76580-4206-11ea-8265-5f66e27e0de1.gif)


**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**: 
[app-debug-new.zip](https://github.com/fossasia/neurolab-android/files/4122772/app-debug-new.zip)
