### PR TITLE
fix: Rename file feature bug 

### DIFF
--- a/app/src/main/java/io/neurolab/adapters/DataLoggerListAdapter.java
+++ b/app/src/main/java/io/neurolab/adapters/DataLoggerListAdapter.java
@@ -8,6 +8,8 @@ import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v7.widget.CardView;
 import android.support.v7.widget.RecyclerView;
+import android.text.Editable;
+import android.text.TextWatcher;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -15,6 +17,7 @@ import android.widget.EditText;
 import android.widget.FrameLayout;
 import android.widget.ImageView;
 import android.widget.TextView;
+
 import java.io.File;
 import java.util.List;
 
@@ -66,6 +69,7 @@ public class DataLoggerListAdapter extends RecyclerView.Adapter<DataLoggerListAd
             params.rightMargin = context.getResources().getDimensionPixelSize(R.dimen.layout_margin_large);
             enterNameView.setLayoutParams(params);
             container.addView(enterNameView);
+            enterNameView.setText(files.get(i).getName());
             AlertDialog alertDialog = new AlertDialog.Builder(context)
                     .setTitle("Rename the file")
                     .setView(container)
@@ -79,18 +83,38 @@ public class DataLoggerListAdapter extends RecyclerView.Adapter<DataLoggerListAd
                     .setNegativeButton(R.string.cancel, (dialog, which) -> {
                     }).create();
             alertDialog.show();
+            enterNameView.addTextChangedListener(new TextWatcher() {
+                @Override
+                public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+                    // No need to be implemented
+                }
+
+                @Override
+                public void onTextChanged(CharSequence s, int start, int before, int count) {
+                    if (enterNameView.getText().toString().length() > 0) {
+                        alertDialog.getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(true);
+                    }
+                }
+
+                @Override
+                public void afterTextChanged(Editable s) {
+                    if (enterNameView.getText().toString().length() <= 0) {
+                        alertDialog.getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(false);
+                    }
+                }
+            });
         });
         viewHolder.deleteFileView.setOnClickListener(v -> {
             FrameLayout container = new FrameLayout(context);
             AlertDialog alertDialog = new AlertDialog.Builder(context)
                     .setTitle("Delete file " + files.get(i).getName())
                     .setView(container).
-                    setPositiveButton(R.string.ok_button, ((dialog, which) -> {
-                        FilePathUtil.deleteFile(files.get(i));
-                        files.remove(i);
-                        notifyItemRemoved(i);
-                        notifyItemRangeChanged(i,1);
-                    }))
+                            setPositiveButton(R.string.ok_button, ((dialog, which) -> {
+                                FilePathUtil.deleteFile(files.get(i));
+                                files.remove(i);
+                                notifyItemRemoved(i);
+                                notifyItemRangeChanged(i, 1);
+                            }))
                     .setNegativeButton(R.string.cancel, ((dialog, which) -> {
                     })).create();
             alertDialog.show();


### PR DESCRIPTION
Fixes #600 
**Changes**: 

Disable the "ok" button when trying to rename the file with no name.

**Gif for the changes**: 

![ezgif com-optimize](https://user-images.githubusercontent.com/31280303/73303351-5503ba00-423c-11ea-86e1-b27a7cf36a49.gif)

**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**:
[app-debug.zip](https://github.com/fossasia/neurolab-android/files/4124488/app-debug.zip)
