### PR TITLE
Fixes AboutUs background to light theme

### DIFF
--- a/app/src/main/java/io/neurolab/activities/AboutUsActivity.java
+++ b/app/src/main/java/io/neurolab/activities/AboutUsActivity.java
@@ -2,6 +2,7 @@ package io.neurolab.activities;
 
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
+import android.support.v7.app.AppCompatDelegate;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.FrameLayout;
@@ -28,6 +29,8 @@ public class AboutUsActivity extends AppCompatActivity {
                 .addInstagram("fossasia")
                 .addGitHub("fossasia")
                 .create();
+
+        AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO);
         FrameLayout frameLayout = new FrameLayout(this);
         FrameLayout.LayoutParams params = new FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT);
         frameLayout.setLayoutParams(params);


### PR DESCRIPTION
Fixes #615 

**Changes**:
Sets the theme to light theme. About Us activity wont show with dark background unlike the rest of the app.

**Screenshot/s for the changes**:

![20200131_230152](https://user-images.githubusercontent.com/18425237/73560884-da29e180-447d-11ea-8463-9b6c352ce05c.gif)

 
**Checklist**: 
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**: 
[feature.zip](https://github.com/fossasia/neurolab-android/files/4140619/feature.zip)

