### PR TITLE
Fixes #629

### DIFF
--- a/app/src/main/java/io/neurolab/activities/MeditationActivity.java
+++ b/app/src/main/java/io/neurolab/activities/MeditationActivity.java
@@ -58,7 +58,7 @@ public final class MeditationActivity extends AppCompatActivity {
 
             setTrackName(MEDIA_RES_ID);
 
-            durationView.setText(savedInstanceState.getCharSequence("Max"));
+            durationView.setText(savedInstanceState.getCharSequence(KEY_DURATIONVIEW));
 
             mediaPlayerHolder = (MediaPlayerHolder)savedInstanceState.getSerializable(KEY_PLAYER);
             mediaPlayerHolder.setPlaybackInfoListener(new PlaybackListener());

--- a/app/src/main/java/io/neurolab/activities/MeditationActivity.java
+++ b/app/src/main/java/io/neurolab/activities/MeditationActivity.java
@@ -60,11 +60,11 @@ public final class MeditationActivity extends AppCompatActivity {
 
             durationView.setText(savedInstanceState.getCharSequence("Max"));
 
-            mediaPlayerHolder=(MediaPlayerHolder)savedInstanceState.getSerializable(KEY_PLAYER);
+            mediaPlayerHolder = (MediaPlayerHolder)savedInstanceState.getSerializable(KEY_PLAYER);
             mediaPlayerHolder.setPlaybackInfoListener(new PlaybackListener());
             mediaPlayerHolder.initializeProgressCallback();
 
-            playerAdapter=mediaPlayerHolder;
+            playerAdapter = mediaPlayerHolder;
         }
     }
     @Override

--- a/app/src/main/java/io/neurolab/activities/MeditationActivity.java
+++ b/app/src/main/java/io/neurolab/activities/MeditationActivity.java
@@ -21,6 +21,8 @@ public final class MeditationActivity extends AppCompatActivity {
 
     public static final String TAG = MeditationActivity.class.getCanonicalName();   // TAG for debugging purposes.
     public static int MEDIA_RES_ID;
+    private static String KEY_PLAYER = "PlayerAdapter_Key";
+    private static String KEY_DURATIONVIEW = "DurationView_Key";
 
     // Necessary view references.
     private SeekBar seekbarAudio;
@@ -30,6 +32,7 @@ public final class MeditationActivity extends AppCompatActivity {
 
     // the interface reference which would be used to control the media session from this UI client.
     private PlayerAdapter playerAdapter;
+    private MediaPlayerHolder mediaPlayerHolder;
 
     private boolean isUserSeeking = false;
 
@@ -41,24 +44,46 @@ public final class MeditationActivity extends AppCompatActivity {
 
         MEDIA_RES_ID = getIntent().getIntExtra(MEDITATION_DIR_KEY, R.raw.soften_and_relax);
 
-        grabNecessaryReferencesAndSetListeners();
+        if (savedInstanceState == null) {
+            grabNecessaryReferencesAndSetListeners();
 
-        setTrackName(MEDIA_RES_ID);
+            setTrackName(MEDIA_RES_ID);
 
-        initializePlaybackController();
+            initializePlaybackController();
+
+            playerAdapter.loadMedia(MEDIA_RES_ID);
+        }
+        else {
+            grabNecessaryReferencesAndSetListeners();
+
+            setTrackName(MEDIA_RES_ID);
+
+            durationView.setText(savedInstanceState.getCharSequence("Max"));
+
+            mediaPlayerHolder=(MediaPlayerHolder)savedInstanceState.getSerializable(KEY_PLAYER);
+            mediaPlayerHolder.setPlaybackInfoListener(new PlaybackListener());
+            mediaPlayerHolder.initializeProgressCallback();
+
+            playerAdapter=mediaPlayerHolder;
+        }
+    }
+    @Override
+    protected void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        outState.putSerializable(KEY_PLAYER, mediaPlayerHolder);
+        outState.putCharSequence(KEY_DURATIONVIEW,durationView.getText());
     }
 
     @Override
     protected void onStart() {
         super.onStart();
-        playerAdapter.loadMedia(MEDIA_RES_ID);
     }
 
     @Override
     protected void onStop() {
         super.onStop();
         // not releasing the media player resources during auto-rotation. I believe it won't make it logical for the user to listen to the audio again from the start if he rotates his phone.
-        if (isChangingConfigurations() && playerAdapter.isPlaying()) {
+        if (isChangingConfigurations()) {
             Log.d(TAG, "onStop: don't release MediaPlayer as screen is rotating & playing");
         } else {
             playerAdapter.release();
@@ -114,7 +139,7 @@ public final class MeditationActivity extends AppCompatActivity {
     }
 
     private void initializePlaybackController() {
-        MediaPlayerHolder mediaPlayerHolder = new MediaPlayerHolder(this);
+        mediaPlayerHolder = new MediaPlayerHolder(this);
         Log.d(TAG, "Inside initializePlaybackController method: MediaPlayerHolder Created");
         mediaPlayerHolder.setPlaybackInfoListener(new PlaybackListener());
         playerAdapter = mediaPlayerHolder;

--- a/app/src/main/java/io/neurolab/main/output/audio/PlayerAdapter.java
+++ b/app/src/main/java/io/neurolab/main/output/audio/PlayerAdapter.java
@@ -1,7 +1,9 @@
 package io.neurolab.main.output.audio;
 
+import java.io.Serializable;
+
 // An Interface which allows the client Activity (containing the Media Controller UI) to control playback functions.
-public interface PlayerAdapter {
+public interface PlayerAdapter extends Serializable {
 
     void loadMedia(int resourceId);
 


### PR DESCRIPTION
Fixes #629 

**Changes**:
Object of the media player is saved before orientation change and restored. The seek-bar remembers its position and the buttons are connected to the player after state change.

**Screenshot/s for the changes**:
![20200214_230002](https://user-images.githubusercontent.com/18425237/74553719-ea61b680-4f7d-11ea-9159-6bd63e162630.gif)

**Checklist**:
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**:
[feature.zip](https://github.com/fossasia/neurolab-android/files/4205749/feature.zip)
