### PR TITLE
Fixes #634 Play/Pause in Meditation player.

### DIFF
--- a/app/src/main/java/io/neurolab/activities/MeditationActivity.java
+++ b/app/src/main/java/io/neurolab/activities/MeditationActivity.java
@@ -96,7 +96,7 @@ public final class MeditationActivity extends AppCompatActivity {
                 view -> {
                     playerAdapter.reset();
                     playButton.setVisibility(View.VISIBLE);
-                    pauseButton.setVisibility(View.INVISIBLE);
+                    pauseButton.setVisibility(View.GONE);
                 });
 
         setSeekbarListener();

--- a/app/src/main/java/io/neurolab/activities/MeditationActivity.java
+++ b/app/src/main/java/io/neurolab/activities/MeditationActivity.java
@@ -6,6 +6,7 @@ import android.support.v4.media.session.PlaybackStateCompat;
 import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 import android.util.TypedValue;
+import android.view.View;
 import android.widget.SeekBar;
 import android.widget.TextView;
 
@@ -75,13 +76,28 @@ public final class MeditationActivity extends AppCompatActivity {
         progressTimeView = findViewById(R.id.progress_time);
         durationView = findViewById(R.id.duration_view);
         trackNameView = findViewById(R.id.track_name);
+        pauseButton.setVisibility(View.GONE); // The pause button should be invisible initially
 
+        //Handling Play-Pause-Reset buttons according to the player state.
         pauseButton.setOnClickListener(
-                view -> playerAdapter.pause());
+                view -> {
+                    playerAdapter.pause();
+                    pauseButton.setVisibility(View.GONE);
+                    playButton.setVisibility(View.VISIBLE);
+                });
+
         playButton.setOnClickListener(
-                view -> playerAdapter.play());
+                view -> {
+                    playerAdapter.play();
+                    pauseButton.setVisibility(View.VISIBLE);
+                    playButton.setVisibility(View.GONE);
+                });
         resetButton.setOnClickListener(
-                view -> playerAdapter.reset());
+                view -> {
+                    playerAdapter.reset();
+                    playButton.setVisibility(View.VISIBLE);
+                    pauseButton.setVisibility(View.INVISIBLE);
+                });
 
         setSeekbarListener();
     }


### PR DESCRIPTION
Fixes #634 

**Changes**: 
- The pause button was made invisible initially 
- Then the onClick functions of both play and pause buttons were extended to control the buttons' visibility. 

**Screenshot/s for the changes**: 
<img src="https://user-images.githubusercontent.com/53938155/74864790-157d4900-5376-11ea-91d1-9e33ccb7a84d.gif" width=200/>

**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**: 
[mediabuttons.zip](https://github.com/fossasia/neurolab-android/files/4226862/mediabuttons.zip)

