### PR TITLE
Updated Libraries And Dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Please check out the in-development features of the app like the Meditation mode
 *   [Preference Fix Library](https://github.com/Gericop/Android-Support-Preference-V7-Fix)
 *   [JSyn Library](http://www.softsynth.com/jsyn/beta/jsyn_on_android.php)
 *   [Android About Page](https://github.com/medyo/android-about-page)
-*   [Open Sound Control library](https://github.com/medyo/android-about-page)
+*   [Open Sound Control library](https://mvnrepository.com/artifact/com.illposed.osc/javaosc-core)
 *   [Java Simple Serial Connector](https://mvnrepository.com/artifact/org.scream3r/jssc/2.8.0)
 *   [JTransforms](https://mvnrepository.com/artifact/net.sourceforge.jtransforms/jtransforms/2.4.0)
 *   [Java Open GL](https://mvnrepository.com/artifact/org.jogamp.jogl/jogl-all-main/2.3.2)

--- a/build.gradle
+++ b/build.gradle
@@ -60,4 +60,4 @@ ext {
     appIntroLibraryVersion = '4.2.3'
     jfreechartLibraryVersion = '1.0.14'
     opencsvLibraryVersion = '5.0'
-}  
+}

--- a/build.gradle
+++ b/build.gradle
@@ -59,5 +59,5 @@ ext {
     usbSerialLibraryVersion = '6.1.0'
     appIntroLibraryVersion = '4.2.3'
     jfreechartLibraryVersion = '1.0.14'
-    opencsvLibraryVersion = '5.0'
+    opencsvLibraryVersion = '5.0' 
 }

--- a/build.gradle
+++ b/build.gradle
@@ -60,4 +60,4 @@ ext {
     appIntroLibraryVersion = '4.2.3'
     jfreechartLibraryVersion = '1.0.14'
     opencsvLibraryVersion = '5.0'
-}
+}  

--- a/build.gradle
+++ b/build.gradle
@@ -38,16 +38,16 @@ ext {
 
     // App Dependencies
     supportLibraryVersion = '28.0.0'
-    constraintLayoutVersion = '2.0.1'
+    constraintLayoutVersion = '2.0.4'
     prefFixLibraryVersion = '28.0.0.0'
 
     // Test Dependencies
     testRunnerRulesVersion = '1.0.2'
-    junitVersion = '4.13'
+    junitVersion = '4.13.1'
     espressoVersion = '3.0.2'
 
     // External Libraries
-    gsonLibraryVersion = '2.8.5'
+    gsonLibraryVersion = '2.8.6'
     aboutPageLibraryVersion = '1.2.5'
     jsynLibraryVersion = '16.8.0a'
     javaOscLibraryVersion = '0.3'


### PR DESCRIPTION
Fixes #682  

**Changes**: 

App Dependencies
constraintLayoutVersion '2.0.1' to '2.0.4'

Test Dependencies
junitVersion '4.13' to '4.13.1'

External Libraries
gsonLibraryVersion '2.8.5' to '2.8.6' 

 

 

 