### PR TITLE
Fixes #646 : App crash fixed on Share click

### DIFF
--- a/app/src/main/java/io/neurolab/activities/ShareDataActivity.java
+++ b/app/src/main/java/io/neurolab/activities/ShareDataActivity.java
@@ -65,10 +65,10 @@ public class ShareDataActivity extends AppCompatActivity {
         File appDir = new File(Environment.getExternalStorageDirectory().getAbsolutePath() + File.separator +
                 CSV_DIRECTORY);
         File[] files = appDir.listFiles();
-        fileList = new String[files.length];
-        newFileName = new String[files.length];
 
         if (appDir.listFiles() != null && files.length > 0) {
+            fileList = new String[files.length];
+            newFileName = new String[files.length];
             int j = 0;
             for (int i = 0; i < files.length; i++) {
                 fileList[j] = files[i].getAbsolutePath();
@@ -79,18 +79,20 @@ public class ShareDataActivity extends AppCompatActivity {
             Toast.makeText(this, R.string.share_screen_toast, Toast.LENGTH_SHORT).show();
         }
 
-        if (appDir.listFiles().length == 0) {
+        if (appDir.listFiles() == null) {
             numberOfFiles.setVisibility(View.VISIBLE);
             numberOfFiles.setText(R.string.no_datasets_message);
             shareButton.setVisibility(View.INVISIBLE);
         }
 
-        final List<String> file_list = new ArrayList<String>(Arrays.asList(newFileName));
-        final ArrayAdapter<String> arrayAdapter = new ArrayAdapter<String>
-                (this, android.R.layout.simple_list_item_multiple_choice, file_list);
-        fileListView.setChoiceMode(ListView.CHOICE_MODE_MULTIPLE);
-        fileListView.setItemsCanFocus(false);
-        fileListView.setAdapter(arrayAdapter);
+        if (newFileName != null) {
+            final List<String> file_list = new ArrayList<String>(Arrays.asList(newFileName));
+            final ArrayAdapter<String> arrayAdapter = new ArrayAdapter<String>
+                    (this, android.R.layout.simple_list_item_multiple_choice, file_list);
+            fileListView.setChoiceMode(ListView.CHOICE_MODE_MULTIPLE);
+            fileListView.setItemsCanFocus(false);
+            fileListView.setAdapter(arrayAdapter);
+        }
 
         fileListView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
         @Override


### PR DESCRIPTION
Fixes #646 

**Changes**: [Add here what changes were made in this issue and if possible provide links.]

It was crashing because of NULL pointer exception therefore I added a check if that is NULL and it now works smoothly

**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**: [Compress the `app-debug.apk` file into a `<feature>.rar` or `<feature>.zip` file and upload it here]
[app-debug.zip](https://github.com/fossasia/neurolab-android/files/5975790/app-debug.zip)