### PR TITLE
fix : corrected typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ This repository holds the Android app for the Neurolab Hardware. We are developi
   
 ## Goal
 
-Our brains communicate through neurotransmitters and their activity emits electricity. The neuroheadset measures that electricity on the skin of the forehead and the software processes the signal so that it can be translated into a visual or auditory representation. The data that can be collected can be analyzed to identify mental health, stress, relaxation and even diseases like Alzheimer. 
+Our brains communicate through neurotransmitters and their activity emits electricity. The neuroheadset measures that electricity on the skin of the forehead and the software processes the signal so that it can be translated into a visual or auditory representation. The data that can be collected can be analyzed to identify mental health, stress, relaxation and even diseases like Alzheimer's. 
 
 Current devices in the medical industry are usually not accessible by doctors due to their high pricing. They are also complicated to use. The idea of the device is to integrate it into a headband and focus on signals that can be obtained through the frontal lobe.
 


### PR DESCRIPTION
Fixes #706 

**Changes**: 
In [Goal](https://github.com/fossasia/neurolab-android#goal) section of Readme , there was a typo error. I corrected it and changed `Alzheimer` to `Alzheimer's`



**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members


